### PR TITLE
feat(database): add postgresql support to app host

### DIFF
--- a/aspire/Beagl.AppHost/AppHost.cs
+++ b/aspire/Beagl.AppHost/AppHost.cs
@@ -1,11 +1,21 @@
 // MIT License - Copyright (c) 2025 Jonathan St-Michel
 
-IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
+IDistributedApplicationBuilder builder =
+    DistributedApplication.CreateBuilder(args);
 
-builder.AddProject("beagl-webapp", "../../src/Beagl.WebApp");
+// Register PostgreSQL database
+IResourceBuilder<PostgresServerResource> postgresServer = builder.AddPostgres("postgres-server");
+IResourceBuilder<PostgresDatabaseResource> postgresdb = postgresServer.AddDatabase("postgres-db");
+
+// Register Beagl web application
+builder.AddProject("beagl-webapp", "../../src/Beagl.WebApp")
+    .WaitFor(postgresdb)
+    .WithReference(postgresdb);
 
 // builder.AddDockerfile("beagl-webapp-docker", "../../src/Beagl.WebApp")
 //     .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
-//     .WithHttpEndpoint(8080, 8080);
+//     .WithHttpEndpoint(8080, 8080)
+//     .WaitFor(postgresdb)
+//     .WithReference(postgresdb);
 
 builder.Build().Run();

--- a/aspire/Beagl.AppHost/Beagl.AppHost.csproj
+++ b/aspire/Beagl.AppHost/Beagl.AppHost.csproj
@@ -12,4 +12,8 @@
     <UserSecretsId>7107e9ec-1447-41aa-9d32-34ee9ce23f65</UserSecretsId>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="*" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request adds PostgreSQL integration to the application host and ensures the web application depends on the database. The main changes are the registration of the PostgreSQL server and database resources, updating the web application project to wait for and reference the database, and adding the necessary package dependency.

**Database integration:**
* Registered a PostgreSQL server and database using `AddPostgres` and `AddDatabase` in `AppHost.cs`.
* Updated the web application registration to wait for and reference the PostgreSQL database, ensuring proper startup order and connectivity.

**Dependencies:**
* Added the `Aspire.Hosting.PostgreSQL` NuGet package to the project file to enable PostgreSQL resource registration.

Closes #15