### PR TITLE
feat(webapp): add first-run setup wizard for initial admin

### DIFF
--- a/src/Beagl.Application/Setup/Dtos/CompleteInitialSetupRequest.cs
+++ b/src/Beagl.Application/Setup/Dtos/CompleteInitialSetupRequest.cs
@@ -1,0 +1,14 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Application.Setup.Dtos;
+
+/// <summary>
+/// Represents the request payload used to complete first-run setup.
+/// </summary>
+/// <param name="UserName">The administrator user name.</param>
+/// <param name="Email">The administrator email address.</param>
+/// <param name="Password">The administrator password.</param>
+public sealed record CompleteInitialSetupRequest(
+    string UserName,
+    string Email,
+    string Password);

--- a/src/Beagl.Application/Setup/Services/IInitialSetupService.cs
+++ b/src/Beagl.Application/Setup/Services/IInitialSetupService.cs
@@ -1,0 +1,27 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Setup.Dtos;
+using Beagl.Domain.Results;
+
+namespace Beagl.Application.Setup.Services;
+
+/// <summary>
+/// Provides first-run application setup workflows.
+/// </summary>
+public interface IInitialSetupService
+{
+    /// <summary>
+    /// Determines whether first-run setup is still required.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> when setup is required; otherwise, <see langword="false"/>.</returns>
+    public Task<bool> IsSetupRequiredAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Completes first-run setup by creating the initial verified administrator.
+    /// </summary>
+    /// <param name="request">The setup request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The setup result.</returns>
+    public Task<Result> CompleteInitialSetupAsync(CompleteInitialSetupRequest request, CancellationToken cancellationToken);
+}

--- a/src/Beagl.Application/Setup/Services/InitialSetupService.cs
+++ b/src/Beagl.Application/Setup/Services/InitialSetupService.cs
@@ -1,0 +1,97 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System.ComponentModel.DataAnnotations;
+using Beagl.Application.Setup.Dtos;
+using Beagl.Domain.Results;
+using Beagl.Domain.Users;
+
+namespace Beagl.Application.Setup.Services;
+
+/// <summary>
+/// Implements first-run setup workflows.
+/// </summary>
+/// <param name="userRepository">The user repository.</param>
+public sealed class InitialSetupService(IUserRepository userRepository) : IInitialSetupService
+{
+    private static readonly EmailAddressAttribute _emailValidator = new();
+    private readonly IUserRepository _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+
+    /// <inheritdoc />
+    public async Task<bool> IsSetupRequiredAsync(CancellationToken cancellationToken)
+    {
+        bool hasAdministrator = await _userRepository.HasAnyAdministratorAsync(cancellationToken).ConfigureAwait(false);
+        return !hasAdministrator;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> CompleteInitialSetupAsync(CompleteInitialSetupRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Result validation = ValidateRequest(request);
+        if (validation.IsFailure)
+        {
+            return validation;
+        }
+
+        bool hasAdministrator = await _userRepository.HasAnyAdministratorAsync(cancellationToken).ConfigureAwait(false);
+        if (hasAdministrator)
+        {
+            return Result.Failure(new ResultError("setup.already_completed", "Initial setup has already been completed."));
+        }
+
+        CreateUserAccount createAdministrator = new(
+            request.UserName.Trim(),
+            request.Email.Trim(),
+            null,
+            request.Password,
+            UserRole.Administrator,
+            EmailConfirmed: true);
+
+        Result<UserAccount> createResult = await _userRepository
+            .CreateAsync(createAdministrator, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (createResult.IsFailure)
+        {
+            return Result.Failure(createResult.Error!);
+        }
+
+        return Result.Success();
+    }
+
+    private static Result ValidateRequest(CompleteInitialSetupRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserName))
+        {
+            return Result.Failure(new ResultError("setup.user_name_required", "A user name is required."));
+        }
+
+        if (request.UserName.Trim().Length > 256)
+        {
+            return Result.Failure(new ResultError("setup.user_name_too_long", "The user name must contain at most 256 characters."));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Email))
+        {
+            return Result.Failure(new ResultError("setup.email_required", "An email address is required."));
+        }
+
+        if (!_emailValidator.IsValid(request.Email.Trim()))
+        {
+            return Result.Failure(new ResultError("setup.invalid_email", "The email address is not valid."));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Password))
+        {
+            return Result.Failure(new ResultError("setup.password_required", "A password is required."));
+        }
+
+        if (request.Password.Trim().Length < 8)
+        {
+            return Result.Failure(new ResultError("setup.password_too_short", "The password must contain at least 8 characters."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/Beagl.Domain/Users/CreateUserAccount.cs
+++ b/src/Beagl.Domain/Users/CreateUserAccount.cs
@@ -10,9 +10,11 @@ namespace Beagl.Domain.Users;
 /// <param name="PhoneNumber">The phone number.</param>
 /// <param name="Password">The initial password.</param>
 /// <param name="Role">The target user role.</param>
+/// <param name="EmailConfirmed">A value indicating whether the email is confirmed at creation time.</param>
 public sealed record CreateUserAccount(
     string UserName,
     string? Email,
     string? PhoneNumber,
     string Password,
-    UserRole Role);
+    UserRole Role,
+    bool EmailConfirmed = false);

--- a/src/Beagl.Domain/Users/IUserRepository.cs
+++ b/src/Beagl.Domain/Users/IUserRepository.cs
@@ -10,6 +10,13 @@ namespace Beagl.Domain.Users;
 public interface IUserRepository
 {
     /// <summary>
+    /// Determines whether at least one administrator account exists.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> when an administrator exists; otherwise, <see langword="false"/>.</returns>
+    public Task<bool> HasAnyAdministratorAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     /// Retrieves global users metrics.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
+++ b/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
@@ -22,6 +22,20 @@ public sealed class IdentityUserRepository(
     private readonly ApplicationDbContext _applicationDbContext = applicationDbContext ?? throw new ArgumentNullException(nameof(applicationDbContext));
 
     /// <inheritdoc />
+    public async Task<bool> HasAnyAdministratorAsync(CancellationToken cancellationToken)
+    {
+        string administratorRoleName = UserRole.Administrator.ToString();
+
+        return await (
+                from userRole in _applicationDbContext.Set<IdentityUserRole<string>>().AsNoTracking()
+                join role in _applicationDbContext.Roles.AsNoTracking() on userRole.RoleId equals role.Id
+                where role.Name == administratorRoleName
+                select userRole.UserId)
+            .AnyAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public async Task<UsersMetrics> GetMetricsAsync(CancellationToken cancellationToken)
     {
         IQueryable<ApplicationUser> usersQuery = _userManager.Users.AsNoTracking();
@@ -113,6 +127,7 @@ public sealed class IdentityUserRepository(
             UserName = user.UserName,
             Email = user.Email,
             PhoneNumber = user.PhoneNumber,
+            EmailConfirmed = user.EmailConfirmed,
         };
 
         IdentityResult createResult = await _userManager.CreateAsync(identityUser, user.Password).ConfigureAwait(false);

--- a/src/Beagl.WebApp/Components/Pages/Setup.razor
+++ b/src/Beagl.WebApp/Components/Pages/Setup.razor
@@ -1,0 +1,232 @@
+@page "/setup"
+@rendermode InteractiveServer
+@using Beagl.Application.Setup.Dtos
+@using Beagl.Application.Setup.Services
+@inject IInitialSetupService InitialSetupService
+@inject NavigationManager NavigationManager
+@inject IStringLocalizer<SetupResource> L
+
+<PageTitle>@L["Setup.PageTitle"]</PageTitle>
+
+<section class="setup-page-shell">
+    <div class="container py-4 py-lg-5">
+        <article class="setup-surface mx-auto">
+            <header class="setup-header">
+                <p class="setup-kicker mb-2">@L["Setup.Kicker"]</p>
+                <h1 class="setup-title">@L["Setup.Title"]</h1>
+                <p class="setup-copy mb-0">@L["Setup.Copy"]</p>
+            </header>
+
+            @if (_isCheckingSetup)
+            {
+                <div class="setup-loading" role="status" aria-live="polite">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">@L["Setup.Loading"]</span>
+                    </div>
+                </div>
+            }
+            else if (!_isSetupRequired)
+            {
+                <div class="alert alert-success mb-0" role="status">@L["Setup.AlreadyCompleted"]</div>
+            }
+            else
+            {
+                <ol class="setup-steps" aria-label="@L["Setup.Steps.Aria"]">
+                    <li class="@(CurrentStep == SetupStep.Account ? "is-active" : "")">@L["Setup.Step.Account"]</li>
+                    <li class="@(CurrentStep == SetupStep.Confirmation ? "is-active" : "")">@L["Setup.Step.Confirmation"]</li>
+                </ol>
+
+                @if (!string.IsNullOrWhiteSpace(_errorMessage))
+                {
+                    <div class="alert alert-danger" role="alert">@_errorMessage</div>
+                }
+
+                @if (CurrentStep == SetupStep.Account)
+                {
+                    <EditForm EditContext="_editContext" OnValidSubmit="GoToConfirmationStepAsync" class="setup-form">
+                        <DataAnnotationsValidator />
+
+                        @if (_editContext.GetValidationMessages().Any())
+                        {
+                            <div class="alert alert-danger" role="alert">
+                                <ul class="mb-0 ps-3">
+                                    @foreach (string message in _editContext.GetValidationMessages().Distinct())
+                                    {
+                                        <li>@LocalizeValidationMessage(message)</li>
+                                    }
+                                </ul>
+                            </div>
+                        }
+
+                        <div class="setup-form-grid">
+                            <div>
+                                <label class="form-label" for="setupUserName">@L["Setup.Form.UserName"]</label>
+                                <InputText id="setupUserName" class="form-control" @bind-Value="_form.UserName" />
+                            </div>
+                            <div>
+                                <label class="form-label" for="setupEmail">@L["Setup.Form.Email"]</label>
+                                <InputText id="setupEmail" class="form-control" @bind-Value="_form.Email" />
+                            </div>
+                            <div>
+                                <label class="form-label" for="setupPassword">@L["Setup.Form.Password"]</label>
+                                <InputText id="setupPassword" type="password" class="form-control" @bind-Value="_form.Password" />
+                                <div class="form-text">@L["Setup.Form.PasswordHint"]</div>
+                            </div>
+                        </div>
+
+                        <div class="setup-actions">
+                            <button type="submit" class="btn btn-primary">@L["Setup.Action.Next"]</button>
+                        </div>
+                    </EditForm>
+                }
+                else
+                {
+                    <div class="setup-summary" data-testid="setup-confirmation">
+                        <p class="mb-2">@L["Setup.Confirmation.Description"]</p>
+                        <dl class="setup-summary-grid mb-0">
+                            <div>
+                                <dt>@L["Setup.Form.UserName"]</dt>
+                                <dd>@_form.UserName</dd>
+                            </div>
+                            <div>
+                                <dt>@L["Setup.Form.Email"]</dt>
+                                <dd>@_form.Email</dd>
+                            </div>
+                            <div>
+                                <dt>@L["Setup.Confirmation.Role"]</dt>
+                                <dd>@L["Setup.Confirmation.Role.Administrator"]</dd>
+                            </div>
+                            <div>
+                                <dt>@L["Setup.Confirmation.Verification"]</dt>
+                                <dd>@L["Setup.Confirmation.Verified"]</dd>
+                            </div>
+                        </dl>
+                    </div>
+
+                    <div class="setup-actions">
+                        <button type="button" class="btn btn-outline-secondary" @onclick="GoToAccountStep">@L["Setup.Action.Back"]</button>
+                        <button type="button" class="btn btn-primary" @onclick="CompleteSetupAsync" disabled="@_isSubmitting">@L["Setup.Action.Submit"]</button>
+                    </div>
+                }
+            }
+        </article>
+    </div>
+</section>
+
+@code {
+    private readonly SetupFormModel _form = new();
+    private EditContext _editContext = default!;
+    private bool _isCheckingSetup = true;
+    private bool _isSetupRequired;
+    private bool _isSubmitting;
+    private string? _errorMessage;
+
+    private SetupStep CurrentStep { get; set; } = SetupStep.Account;
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        _editContext = new EditContext(_form);
+        _isSetupRequired = await InitialSetupService.IsSetupRequiredAsync(CancellationToken.None).ConfigureAwait(false);
+        _isCheckingSetup = false;
+
+        if (!_isSetupRequired)
+        {
+            NavigationManager.NavigateTo("/", replace: true);
+        }
+    }
+
+    private Task GoToConfirmationStepAsync()
+    {
+        _errorMessage = null;
+        CurrentStep = SetupStep.Confirmation;
+        return Task.CompletedTask;
+    }
+
+    private void GoToAccountStep()
+    {
+        _errorMessage = null;
+        CurrentStep = SetupStep.Account;
+    }
+
+    private async Task CompleteSetupAsync()
+    {
+        _isSubmitting = true;
+        _errorMessage = null;
+
+        CompleteInitialSetupRequest request = new(
+            _form.UserName,
+            _form.Email,
+            _form.Password);
+
+        Beagl.Domain.Results.Result result = await InitialSetupService
+            .CompleteInitialSetupAsync(request, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            _errorMessage = LocalizeError(result.Error!);
+            _isSubmitting = false;
+            return;
+        }
+
+        NavigationManager.NavigateTo("/", replace: true);
+    }
+
+    private string LocalizeError(Beagl.Domain.Results.ResultError error)
+    {
+        LocalizedString localizedError = L[error.Code];
+        return localizedError.ResourceNotFound ? error.Message : localizedError.Value;
+    }
+
+    private string LocalizeValidationMessage(string message)
+    {
+        LocalizedString localizedMessage = L[message];
+        return localizedMessage.ResourceNotFound ? message : localizedMessage.Value;
+    }
+
+    private enum SetupStep
+    {
+        Account,
+        Confirmation,
+    }
+
+    private sealed class SetupFormModel : IValidatableObject
+    {
+        public string UserName { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        public string Password { get; set; } = string.Empty;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (string.IsNullOrWhiteSpace(UserName))
+            {
+                yield return new ValidationResult("setup.user_name_required", [nameof(UserName)]);
+            }
+            else if (UserName.Trim().Length > 256)
+            {
+                yield return new ValidationResult("setup.user_name_too_long", [nameof(UserName)]);
+            }
+
+            if (string.IsNullOrWhiteSpace(Email))
+            {
+                yield return new ValidationResult("setup.email_required", [nameof(Email)]);
+            }
+            else if (!new EmailAddressAttribute().IsValid(Email.Trim()))
+            {
+                yield return new ValidationResult("setup.invalid_email", [nameof(Email)]);
+            }
+
+            if (string.IsNullOrWhiteSpace(Password))
+            {
+                yield return new ValidationResult("setup.password_required", [nameof(Password)]);
+            }
+            else if (Password.Trim().Length < 8)
+            {
+                yield return new ValidationResult("setup.password_too_short", [nameof(Password)]);
+            }
+        }
+    }
+}

--- a/src/Beagl.WebApp/Components/Routes.razor
+++ b/src/Beagl.WebApp/Components/Routes.razor
@@ -1,7 +1,10 @@
 @using Beagl.WebApp.Components.Layout
+@using Beagl.Application.Setup.Services
 @inject IStringLocalizer<ErrorResource> L
+@inject IInitialSetupService InitialSetupService
+@inject NavigationManager NavigationManager
 
-<Router AppAssembly="typeof(Program).Assembly">
+<Router AppAssembly="typeof(Program).Assembly" OnNavigateAsync="HandleNavigateAsync">
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
@@ -14,10 +17,33 @@
                         <p class="users-kicker mb-3">@L["NotFound.Kicker"]</p>
                         <h1 class="display-6 fw-semibold">@L["NotFound.Title"]</h1>
                         <p class="text-secondary mb-4">@L["NotFound.Description"]</p>
-                        <a class="btn btn-primary px-4" href="/employee/users">@L["NotFound.Action.Users"]</a>
+                        <a class="btn btn-primary px-4" href="/">@L["NotFound.Action.Users"]</a>
                     </div>
                 </div>
             </section>
         </LayoutView>
     </NotFound>
 </Router>
+
+@code {
+    private async Task HandleNavigateAsync(NavigationContext navigationContext)
+    {
+        bool setupRequired = await InitialSetupService
+            .IsSetupRequiredAsync(navigationContext.CancellationToken)
+            .ConfigureAwait(false);
+
+        string path = "/" + navigationContext.Path.Trim('/');
+        bool isSetupRoute = string.Equals(path, "/setup", StringComparison.OrdinalIgnoreCase);
+
+        if (setupRequired && !isSetupRoute)
+        {
+            NavigationManager.NavigateTo("/setup", replace: true);
+            return;
+        }
+
+        if (!setupRequired && isSetupRoute)
+        {
+            NavigationManager.NavigateTo("/", replace: true);
+        }
+    }
+}

--- a/src/Beagl.WebApp/Program.cs
+++ b/src/Beagl.WebApp/Program.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Beagl.Infrastructure;
 using Beagl.Infrastructure.Users;
 using Beagl.Infrastructure.Users.Entities;
+using Beagl.Application.Setup.Services;
 using Beagl.Application.Users.Services;
 using Beagl.Domain.Users;
 using Beagl.WebApp.Authentication;
@@ -61,6 +62,7 @@ builder.Services.ConfigureApplicationCookie(options =>
 
 builder.Services.AddScoped<IUserRepository, IdentityUserRepository>();
 builder.Services.AddScoped<IUserManagementService, UserManagementService>();
+builder.Services.AddScoped<IInitialSetupService, InitialSetupService>();
 builder.Services.AddScoped<ISharedLoginService, SharedLoginService>();
 
 builder.Services.AddHsts(options =>

--- a/src/Beagl.WebApp/Resources/Resources.SetupResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.SetupResource.fr.resx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value></resheader>
+  <data name="Setup.PageTitle" xml:space="preserve"><value>Configuration initiale</value></data>
+  <data name="Setup.Kicker" xml:space="preserve"><value>Assistant d'installation</value></data>
+  <data name="Setup.Title" xml:space="preserve"><value>Configurez votre premier compte administrateur</value></data>
+  <data name="Setup.Copy" xml:space="preserve"><value>Complétez cet assistant pour marquer l'application comme prête. Le premier compte est créé comme administrateur vérifié.</value></data>
+  <data name="Setup.Loading" xml:space="preserve"><value>Vérification du statut de configuration</value></data>
+  <data name="Setup.AlreadyCompleted" xml:space="preserve"><value>La configuration initiale est déjà complétée. Redirection vers l'accueil.</value></data>
+  <data name="Setup.Steps.Aria" xml:space="preserve"><value>Étapes de configuration</value></data>
+  <data name="Setup.Step.Account" xml:space="preserve"><value>Compte administrateur</value></data>
+  <data name="Setup.Step.Confirmation" xml:space="preserve"><value>Confirmation</value></data>
+  <data name="Setup.Form.UserName" xml:space="preserve"><value>Nom d'utilisateur</value></data>
+  <data name="Setup.Form.Email" xml:space="preserve"><value>Courriel</value></data>
+  <data name="Setup.Form.Password" xml:space="preserve"><value>Mot de passe</value></data>
+  <data name="Setup.Form.PasswordHint" xml:space="preserve"><value>Utilisez au moins 8 caractères.</value></data>
+  <data name="Setup.Action.Next" xml:space="preserve"><value>Vérifier la configuration</value></data>
+  <data name="Setup.Action.Back" xml:space="preserve"><value>Retour</value></data>
+  <data name="Setup.Action.Submit" xml:space="preserve"><value>Terminer la configuration</value></data>
+  <data name="Setup.Confirmation.Description" xml:space="preserve"><value>La soumission créera le compte administrateur vérifié et passera l'application en mode prêt.</value></data>
+  <data name="Setup.Confirmation.Role" xml:space="preserve"><value>Rôle attribué</value></data>
+  <data name="Setup.Confirmation.Role.Administrator" xml:space="preserve"><value>Administrateur</value></data>
+  <data name="Setup.Confirmation.Verification" xml:space="preserve"><value>Statut du compte</value></data>
+  <data name="Setup.Confirmation.Verified" xml:space="preserve"><value>Vérifié</value></data>
+  <data name="setup.already_completed" xml:space="preserve"><value>La configuration initiale est déjà complétée.</value></data>
+  <data name="setup.user_name_required" xml:space="preserve"><value>Un nom d'utilisateur est requis.</value></data>
+  <data name="setup.user_name_too_long" xml:space="preserve"><value>Le nom d'utilisateur doit contenir au maximum 256 caractères.</value></data>
+  <data name="setup.email_required" xml:space="preserve"><value>Une adresse courriel est requise.</value></data>
+  <data name="setup.invalid_email" xml:space="preserve"><value>L'adresse courriel n'est pas valide.</value></data>
+  <data name="setup.password_required" xml:space="preserve"><value>Un mot de passe est requis.</value></data>
+  <data name="setup.password_too_short" xml:space="preserve"><value>Le mot de passe doit contenir au moins 8 caractères.</value></data>
+</root>

--- a/src/Beagl.WebApp/Resources/Resources.SetupResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.SetupResource.resx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value></resheader>
+  <data name="Setup.PageTitle" xml:space="preserve"><value>First-run setup</value></data>
+  <data name="Setup.Kicker" xml:space="preserve"><value>Installation onboarding</value></data>
+  <data name="Setup.Title" xml:space="preserve"><value>Configure your first administrator account</value></data>
+  <data name="Setup.Copy" xml:space="preserve"><value>Complete this wizard to mark the application as ready. The first account is created as a verified administrator.</value></data>
+  <data name="Setup.Loading" xml:space="preserve"><value>Checking setup status</value></data>
+  <data name="Setup.AlreadyCompleted" xml:space="preserve"><value>Setup is already completed. Redirecting to the home page.</value></data>
+  <data name="Setup.Steps.Aria" xml:space="preserve"><value>Setup steps</value></data>
+  <data name="Setup.Step.Account" xml:space="preserve"><value>Administrator account</value></data>
+  <data name="Setup.Step.Confirmation" xml:space="preserve"><value>Confirmation</value></data>
+  <data name="Setup.Form.UserName" xml:space="preserve"><value>User name</value></data>
+  <data name="Setup.Form.Email" xml:space="preserve"><value>Email</value></data>
+  <data name="Setup.Form.Password" xml:space="preserve"><value>Password</value></data>
+  <data name="Setup.Form.PasswordHint" xml:space="preserve"><value>Use at least 8 characters.</value></data>
+  <data name="Setup.Action.Next" xml:space="preserve"><value>Review setup</value></data>
+  <data name="Setup.Action.Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Setup.Action.Submit" xml:space="preserve"><value>Complete setup</value></data>
+  <data name="Setup.Confirmation.Description" xml:space="preserve"><value>Submitting will create the verified administrator account and switch the application to ready mode.</value></data>
+  <data name="Setup.Confirmation.Role" xml:space="preserve"><value>Assigned role</value></data>
+  <data name="Setup.Confirmation.Role.Administrator" xml:space="preserve"><value>Administrator</value></data>
+  <data name="Setup.Confirmation.Verification" xml:space="preserve"><value>Account status</value></data>
+  <data name="Setup.Confirmation.Verified" xml:space="preserve"><value>Verified</value></data>
+  <data name="setup.already_completed" xml:space="preserve"><value>Initial setup has already been completed.</value></data>
+  <data name="setup.user_name_required" xml:space="preserve"><value>A user name is required.</value></data>
+  <data name="setup.user_name_too_long" xml:space="preserve"><value>The user name must contain at most 256 characters.</value></data>
+  <data name="setup.email_required" xml:space="preserve"><value>An email address is required.</value></data>
+  <data name="setup.invalid_email" xml:space="preserve"><value>The email address is not valid.</value></data>
+  <data name="setup.password_required" xml:space="preserve"><value>A password is required.</value></data>
+  <data name="setup.password_too_short" xml:space="preserve"><value>The password must contain at least 8 characters.</value></data>
+</root>

--- a/src/Beagl.WebApp/Resources/SharedResource.cs
+++ b/src/Beagl.WebApp/Resources/SharedResource.cs
@@ -36,3 +36,10 @@ internal sealed class ErrorResource
 internal sealed class AuthResource
 {
 }
+
+/// <summary>
+/// Marker type for first-run setup localization resources.
+/// </summary>
+internal sealed class SetupResource
+{
+}

--- a/src/Beagl.WebApp/wwwroot/app.css
+++ b/src/Beagl.WebApp/wwwroot/app.css
@@ -223,6 +223,135 @@ body {
     position: relative;
 }
 
+.setup-page-shell {
+    position: relative;
+    min-height: calc(100vh - 5rem);
+    display: grid;
+    align-items: center;
+}
+
+.setup-page-shell::before {
+    position: absolute;
+    inset: auto 8% 10% auto;
+    width: min(40vw, 20rem);
+    height: min(40vw, 20rem);
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(78, 170, 171, 0.22), transparent 72%);
+    filter: blur(62px);
+    content: "";
+    pointer-events: none;
+}
+
+.setup-surface {
+    position: relative;
+    z-index: 1;
+    width: min(100%, 48rem);
+    border: 1px solid var(--surface-border);
+    border-radius: calc(var(--radius-xl) + 0.4rem);
+    padding: clamp(1.4rem, 2vw + 1rem, 2.6rem);
+    background: linear-gradient(152deg, rgba(255, 255, 255, 0.97), rgba(241, 250, 250, 0.92));
+    box-shadow: var(--shadow-floating);
+    animation: reveal-up var(--speed-med) var(--ease-standard) both;
+}
+
+.setup-header {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.setup-kicker {
+    color: var(--brand-2);
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.setup-title {
+    margin: 0;
+    font-size: clamp(1.5rem, 1.5vw + 1rem, 2.2rem);
+    font-family: "IBM Plex Sans", "Space Grotesk", sans-serif;
+}
+
+.setup-copy {
+    color: var(--ink-soft);
+}
+
+.setup-loading {
+    min-height: 10rem;
+    display: grid;
+    place-items: center;
+}
+
+.setup-steps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin: 0 0 1rem;
+    padding: 0;
+    list-style: none;
+}
+
+.setup-steps li {
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-pill);
+    padding: 0.45rem 0.9rem;
+    color: var(--ink-soft);
+    font-size: 0.84rem;
+    font-weight: 600;
+}
+
+.setup-steps li.is-active {
+    color: #fff;
+    border-color: transparent;
+    background: linear-gradient(132deg, var(--brand-1), var(--brand-2));
+}
+
+.setup-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.setup-form-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.setup-summary {
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-lg);
+    padding: 1rem;
+    background: color-mix(in srgb, var(--surface-solid) 86%, #edf8f8 14%);
+}
+
+.setup-summary-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.setup-summary-grid dt {
+    margin-bottom: 0.35rem;
+    color: var(--ink-soft);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.setup-summary-grid dd {
+    margin-bottom: 0;
+    font-weight: 600;
+}
+
+.setup-actions {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
 .auth-page-shell {
     position: relative;
     min-height: 100vh;
@@ -646,6 +775,14 @@ body {
     }
 
     .auth-actions .btn {
+        width: 100%;
+    }
+
+    .setup-actions {
+        justify-content: stretch;
+    }
+
+    .setup-actions .btn {
         width: 100%;
     }
 }

--- a/tests/Beagl.Application.Tests/Setup/Services/InitialSetupServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Setup/Services/InitialSetupServiceTests.cs
@@ -1,0 +1,128 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Setup.Dtos;
+using Beagl.Application.Setup.Services;
+using Beagl.Domain.Results;
+using Beagl.Domain.Users;
+using FluentAssertions;
+using Moq;
+
+namespace Beagl.Application.Tests.Setup.Services;
+
+public class InitialSetupServiceTests
+{
+    [Fact]
+    public async Task IsSetupRequiredAsync_WhenNoAdministratorExists_ShouldReturnTrue()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.HasAnyAdministratorAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        InitialSetupService service = new(userRepositoryMock.Object);
+
+        // Act
+        bool result = await service.IsSetupRequiredAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompleteInitialSetupAsync_WithNullRequest_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        InitialSetupService service = new(userRepositoryMock.Object);
+
+        // Act
+        Func<Task> act = async () => await service.CompleteInitialSetupAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task CompleteInitialSetupAsync_WhenSetupAlreadyCompleted_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.HasAnyAdministratorAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        InitialSetupService service = new(userRepositoryMock.Object);
+        CompleteInitialSetupRequest request = new("admin", "admin@example.com", "Password123!");
+
+        // Act
+        Result result = await service.CompleteInitialSetupAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("setup.already_completed");
+        userRepositoryMock.Verify(
+            repository => repository.CreateAsync(It.IsAny<CreateUserAccount>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CompleteInitialSetupAsync_WhenDataIsValid_ShouldCreateVerifiedAdministrator()
+    {
+        // Arrange
+        CreateUserAccount? capturedCreateUser = null;
+
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.HasAnyAdministratorAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        userRepositoryMock
+            .Setup(repository => repository.CreateAsync(It.IsAny<CreateUserAccount>(), It.IsAny<CancellationToken>()))
+            .Callback<CreateUserAccount, CancellationToken>((createUser, _) => capturedCreateUser = createUser)
+            .ReturnsAsync(Result.Success(new UserAccount("user-1", "admin", "admin@example.com", null, true, false, UserRole.Administrator)));
+
+        InitialSetupService service = new(userRepositoryMock.Object);
+        CompleteInitialSetupRequest request = new(" admin ", " admin@example.com ", "Password123!");
+
+        // Act
+        Result result = await service.CompleteInitialSetupAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedCreateUser.Should().NotBeNull();
+        capturedCreateUser!.UserName.Should().Be("admin");
+        capturedCreateUser.Email.Should().Be("admin@example.com");
+        capturedCreateUser.PhoneNumber.Should().BeNull();
+        capturedCreateUser.Role.Should().Be(UserRole.Administrator);
+        capturedCreateUser.EmailConfirmed.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("", "admin@example.com", "Password123!", "setup.user_name_required")]
+    [InlineData("admin", "", "Password123!", "setup.email_required")]
+    [InlineData("admin", "bad-email", "Password123!", "setup.invalid_email")]
+    [InlineData("admin", "admin@example.com", "", "setup.password_required")]
+    [InlineData("admin", "admin@example.com", "short", "setup.password_too_short")]
+    public async Task CompleteInitialSetupAsync_WithInvalidInput_ShouldReturnValidationFailure(
+        string userName,
+        string email,
+        string password,
+        string expectedCode)
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        InitialSetupService service = new(userRepositoryMock.Object);
+
+        CompleteInitialSetupRequest request = new(userName, email, password);
+
+        // Act
+        Result result = await service.CompleteInitialSetupAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be(expectedCode);
+        userRepositoryMock.Verify(
+            repository => repository.HasAnyAdministratorAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs
@@ -16,6 +16,49 @@ namespace Beagl.Infrastructure.Tests.Users;
 public class IdentityUserRepositoryQueryTests
 {
     [Fact]
+    public async Task HasAnyAdministratorAsync_WhenNoAdministratorRoleAssignmentExists_ShouldReturnFalse()
+    {
+        // Arrange
+        await using EfTestHarness harness = EfTestHarness.Create();
+        await harness.SeedRolesAsync(
+            new ApplicationRole
+            {
+                Id = "role-employee",
+                Name = UserRole.Employee.ToString(),
+                NormalizedName = UserRole.Employee.ToString().ToUpperInvariant(),
+            });
+        await harness.SeedUsersAsync(MakeUser("u1", "alice", confirmed: true, lockedOut: false));
+
+        // Act
+        bool hasAdministrator = await harness.Repository.HasAnyAdministratorAsync(CancellationToken.None);
+
+        // Assert
+        hasAdministrator.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HasAnyAdministratorAsync_WhenAdministratorRoleAssignmentExists_ShouldReturnTrue()
+    {
+        // Arrange
+        await using EfTestHarness harness = EfTestHarness.Create();
+        await harness.SeedRolesAsync(
+            new ApplicationRole
+            {
+                Id = "role-admin",
+                Name = UserRole.Administrator.ToString(),
+                NormalizedName = UserRole.Administrator.ToString().ToUpperInvariant(),
+            });
+        await harness.SeedUsersAsync(MakeUser("u1", "alice", confirmed: true, lockedOut: false));
+        await harness.SeedUserRolesAsync(new IdentityUserRole<string> { UserId = "u1", RoleId = "role-admin" });
+
+        // Act
+        bool hasAdministrator = await harness.Repository.HasAnyAdministratorAsync(CancellationToken.None);
+
+        // Assert
+        hasAdministrator.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task GetMetricsAsync_WithNoUsers_ShouldReturnZeroCounts()
     {
         // Arrange

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
@@ -70,7 +70,49 @@ public class IdentityUserRepositoryTests
         result.Value.UserName.Should().Be("alex");
         result.Value.Email.Should().Be("alex@example.com");
         result.Value.PhoneNumber.Should().Be("555-0100");
+        result.Value.EmailConfirmed.Should().BeFalse();
         result.Value.Role.Should().Be(UserRole.Employee);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithEmailConfirmedRequest_ShouldCreateConfirmedUser()
+    {
+        // Arrange
+        ApplicationUser? capturedUser = null;
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+            .Callback<ApplicationUser, string>((user, _) =>
+            {
+                capturedUser = user;
+                capturedUser.Id = "user-1";
+            })
+            .ReturnsAsync(IdentityResult.Success);
+        userManagerMock
+            .Setup(manager => manager.AddToRoleAsync(It.IsAny<ApplicationUser>(), UserRole.Administrator.ToString()))
+            .ReturnsAsync(IdentityResult.Success);
+        userManagerMock
+            .Setup(manager => manager.GetRolesAsync(It.IsAny<ApplicationUser>()))
+            .ReturnsAsync([UserRole.Administrator.ToString()]);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+        CreateUserAccount request = new(
+            "admin",
+            "admin@example.com",
+            null,
+            "Password123!",
+            UserRole.Administrator,
+            EmailConfirmed: true);
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await repository.CreateAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedUser.Should().NotBeNull();
+        capturedUser!.EmailConfirmed.Should().BeTrue();
+        result.Value!.EmailConfirmed.Should().BeTrue();
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Add a first-run onboarding wizard at `/setup` with account and confirmation steps.
- Gate navigation so setup is required until an administrator account exists.
- Introduce setup service flow across Application, Domain, Infrastructure, and WebApp.
- Add bilingual setup localization, UI styling, and automated tests for setup logic.

## Motivation
Enable self-hosted installations to complete initial configuration safely and consistently by creating the first verified administrator through a guided flow.

## Changes
- Add setup use cases (`CompleteInitialSetupRequest`, `IInitialSetupService`, `InitialSetupService`) and enforce setup completion logic.
- Extend user persistence contract and implementation to detect administrator existence and support confirmed-at-create admin setup behavior.
- Add WebApp setup page, route guard integration, localization resources (`en`/`fr`), styling, and setup-focused unit tests.

## Commit Overview
- 193207a feat(webapp): add first-run setup wizard for initial admin
- N/A

## Architectural Impact
- Domain: `CreateUserAccount` now includes `EmailConfirmed`; `IUserRepository` adds `HasAnyAdministratorAsync`.
- Application: New setup DTO and service orchestrate first-run validation and admin creation.
- Infrastructure: Repository query added to detect administrator role assignments; user creation now maps `EmailConfirmed`.
- WebApp: New `/setup` page, router navigation guard, DI registration, setup resource marker and localized resource files, plus setup-specific CSS.

## Database / Migration
N/A (no migration files added; behavior relies on existing Identity tables and role assignments).

## Testing
- Added/updated:
  - `tests/Beagl.Application.Tests/Setup/Services/InitialSetupServiceTests.cs`
  - `tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs`
  - `tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs`
- Tests run:
  - Not documented in this unmerged commit range.
- Coverage impact or N/A:
  - N/A (coverage deltas not recorded in commit metadata).

## How to validate
1. Start from a database without an administrator role assignment and open the app; confirm redirect to `/setup`.
2. Complete setup with username, email, and password; submit from confirmation and verify admin account is created as verified.
3. Reload and navigate normally; confirm `/setup` is no longer required once admin exists.

## Breaking Changes
None