### PR TITLE
feat(webapp): require auth for employee workspace

### DIFF
--- a/src/Beagl.WebApp/Authentication/AuthorizationPolicies.cs
+++ b/src/Beagl.WebApp/Authentication/AuthorizationPolicies.cs
@@ -1,0 +1,26 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Domain.Users;
+
+namespace Beagl.WebApp.Authentication;
+
+/// <summary>
+/// Defines authorization constants used by the employee workspace.
+/// </summary>
+internal static class AuthorizationPolicies
+{
+    /// <summary>
+    /// Gets the policy name for employee workspace access.
+    /// </summary>
+    public const string EmployeeAccess = nameof(EmployeeAccess);
+
+    /// <summary>
+    /// Gets the employee role name.
+    /// </summary>
+    public const string EmployeeRole = nameof(UserRole.Employee);
+
+    /// <summary>
+    /// Gets the administrator role name.
+    /// </summary>
+    public const string AdministratorRole = nameof(UserRole.Administrator);
+}

--- a/src/Beagl.WebApp/Authentication/SharedLoginService.cs
+++ b/src/Beagl.WebApp/Authentication/SharedLoginService.cs
@@ -1,12 +1,13 @@
 // MIT License - Copyright (c) 2025 Jonathan St-Michel
 
 using Beagl.Infrastructure.Users.Entities;
+using Beagl.Domain.Users;
 using Microsoft.AspNetCore.Identity;
 
 namespace Beagl.WebApp.Authentication;
 
 /// <summary>
-/// Provides a shared sign-in workflow for employees and citizens.
+/// Provides a shared sign-in workflow for employees and administrators.
 /// </summary>
 internal sealed class SharedLoginService(
     UserManager<ApplicationUser> userManager,
@@ -21,6 +22,12 @@ internal sealed class SharedLoginService(
         string normalizedIdentifier = identifier.Trim();
         ApplicationUser? user = await FindUserByIdentifierAsync(normalizedIdentifier).ConfigureAwait(false);
         if (user is null)
+        {
+            return SharedLoginStatus.InvalidCredentials;
+        }
+
+        bool hasEmployeeAccess = await HasEmployeeAccessAsync(user).ConfigureAwait(false);
+        if (!hasEmployeeAccess)
         {
             return SharedLoginStatus.InvalidCredentials;
         }
@@ -57,5 +64,21 @@ internal sealed class SharedLoginService(
 
         ApplicationUser? emailUser = await userManager.FindByEmailAsync(identifier).ConfigureAwait(false);
         return emailUser;
+    }
+
+    private async Task<bool> HasEmployeeAccessAsync(ApplicationUser user)
+    {
+        bool isEmployee = await userManager
+            .IsInRoleAsync(user, nameof(UserRole.Employee))
+            .ConfigureAwait(false);
+
+        if (isEmployee)
+        {
+            return true;
+        }
+
+        return await userManager
+            .IsInRoleAsync(user, nameof(UserRole.Administrator))
+            .ConfigureAwait(false);
     }
 }

--- a/src/Beagl.WebApp/Components/Pages/Home.razor
+++ b/src/Beagl.WebApp/Components/Pages/Home.razor
@@ -1,4 +1,5 @@
 @page "/"
+@attribute [Authorize(Policy = AuthorizationPolicies.EmployeeAccess)]
 @inject IStringLocalizer<HomeResource> L
 
 <PageTitle>@L["Home.Title"]</PageTitle>

--- a/src/Beagl.WebApp/Components/Pages/Users.razor
+++ b/src/Beagl.WebApp/Components/Pages/Users.razor
@@ -1,5 +1,6 @@
 @page "/employee/users"
 @rendermode InteractiveServer
+@attribute [Authorize(Policy = AuthorizationPolicies.EmployeeAccess, Roles = AuthorizationPolicies.AdministratorRole)]
 @inject IUserManagementService UserManagementService
 @inject ILogger<Users> Logger
 @inject IStringLocalizer<UsersResource> L

--- a/src/Beagl.WebApp/Components/Routes.razor
+++ b/src/Beagl.WebApp/Components/Routes.razor
@@ -6,7 +6,11 @@
 
 <Router AppAssembly="typeof(Program).Assembly" OnNavigateAsync="HandleNavigateAsync">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)">
+            <NotAuthorized>
+                <RouteAuthorizationRedirect />
+            </NotAuthorized>
+        </AuthorizeRouteView>
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
     <NotFound>

--- a/src/Beagl.WebApp/Components/Routing/RouteAuthorizationRedirect.razor
+++ b/src/Beagl.WebApp/Components/Routing/RouteAuthorizationRedirect.razor
@@ -1,0 +1,39 @@
+@inject NavigationManager NavigationManager
+
+@code {
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        ArgumentNullException.ThrowIfNull(AuthenticationStateTask);
+
+        AuthenticationState authenticationState = await AuthenticationStateTask.ConfigureAwait(false);
+        string destination = authenticationState.User.Identity?.IsAuthenticated == true
+            ? "/account/access-denied"
+            : BuildLoginUrl();
+
+        if (!IsCurrentDestination(destination))
+        {
+            NavigationManager.NavigateTo(destination, forceLoad: true);
+        }
+    }
+
+    private string BuildLoginUrl()
+    {
+        string relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        string returnUrl = string.IsNullOrWhiteSpace(relativePath)
+            ? "/"
+            : "/" + relativePath;
+
+        return $"/account/login?returnUrl={Uri.EscapeDataString(returnUrl)}";
+    }
+
+    private bool IsCurrentDestination(string destination)
+    {
+        string currentPath = "/" + NavigationManager.ToBaseRelativePath(NavigationManager.Uri).TrimStart('/');
+        string destinationPath = destination.Split('?', 2)[0];
+
+        return string.Equals(currentPath, destinationPath, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Beagl.WebApp/Components/_Imports.razor
+++ b/src/Beagl.WebApp/Components/_Imports.razor
@@ -3,8 +3,12 @@
 @using Beagl.Application.Users.Dtos
 @using Beagl.Application.Users.Services
 @using Beagl.Domain.Users
+@using Beagl.WebApp.Components.Routing
+@using Beagl.WebApp.Authentication
 @using Beagl.Domain.Results
 @using Beagl.WebApp.Resources
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.Extensions.Localization
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Forms

--- a/src/Beagl.WebApp/Pages/Account/AccessDenied.cshtml
+++ b/src/Beagl.WebApp/Pages/Account/AccessDenied.cshtml
@@ -1,0 +1,38 @@
+@page "/account/access-denied"
+@model Beagl.WebApp.Pages.Account.AccessDeniedModel
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Beagl.WebApp.Resources.AuthResource> L
+@{
+    ViewData["Title"] = L["Auth.AccessDenied.PageTitle"];
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap-icons/font/bootstrap-icons.css" />
+    <link rel="stylesheet" href="~/app.css" />
+    <link rel="stylesheet" href="~/Beagl.WebApp.styles.css" />
+</head>
+<body>
+    <section class="auth-page-shell" aria-label="@L["Auth.AccessDenied.PageTitle"]">
+        <article class="auth-card">
+            <a class="app-shell__brand text-decoration-none mb-3" href="/">
+                <span class="app-shell__brand-mark">
+                    <img class="app-shell__brand-logo" src="~/images/beagl_logo.png" alt="@L["Auth.Login.Brand.Alt"]" />
+                </span>
+                <span>@L["Auth.Login.Brand.Name"]</span>
+            </a>
+            <p class="auth-kicker">@L["Auth.AccessDenied.Kicker"]</p>
+            <h1 class="auth-heading">@L["Auth.AccessDenied.Title"]</h1>
+            <p class="auth-copy">@L["Auth.AccessDenied.Description"]</p>
+
+            <div class="auth-actions">
+                <a class="btn btn-primary px-4" href="/">@L["Auth.AccessDenied.Action.Home"]</a>
+            </div>
+        </article>
+    </section>
+</body>
+</html>

--- a/src/Beagl.WebApp/Pages/Account/AccessDenied.cshtml.cs
+++ b/src/Beagl.WebApp/Pages/Account/AccessDenied.cshtml.cs
@@ -1,0 +1,14 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Beagl.WebApp.Pages.Account;
+
+/// <summary>
+/// Renders the access denied page for authenticated users without the required permissions.
+/// </summary>
+[AllowAnonymous]
+internal sealed class AccessDeniedModel : PageModel
+{
+}

--- a/src/Beagl.WebApp/Program.cs
+++ b/src/Beagl.WebApp/Program.cs
@@ -10,6 +10,7 @@ using Beagl.Application.Users.Services;
 using Beagl.Domain.Users;
 using Beagl.WebApp.Authentication;
 using Beagl.WebApp.Extensions;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -17,6 +18,7 @@ using Microsoft.EntityFrameworkCore;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+builder.Services.AddCascadingAuthenticationState();
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
@@ -57,8 +59,17 @@ builder.Services.AddIdentity<ApplicationUser, ApplicationRole>(options =>
 builder.Services.ConfigureApplicationCookie(options =>
 {
     options.LoginPath = "/account/login";
-    options.AccessDeniedPath = "/account/login";
+    options.AccessDeniedPath = "/account/access-denied";
 });
+
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy(
+        AuthorizationPolicies.EmployeeAccess,
+        policy => policy
+            .RequireAuthenticatedUser()
+            .RequireRole(
+                AuthorizationPolicies.EmployeeRole,
+                AuthorizationPolicies.AdministratorRole));
 
 builder.Services.AddScoped<IUserRepository, IdentityUserRepository>();
 builder.Services.AddScoped<IUserManagementService, UserManagementService>();

--- a/src/Beagl.WebApp/Resources/Resources.AuthResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.AuthResource.fr.resx
@@ -7,9 +7,9 @@
   <data name="Auth.Login.PageTitle" xml:space="preserve"><value>Connexion</value></data>
   <data name="Auth.Login.Brand.Alt" xml:space="preserve"><value>Logo Beagl</value></data>
   <data name="Auth.Login.Brand.Name" xml:space="preserve"><value>Beagl CRM</value></data>
-  <data name="Auth.Login.Kicker" xml:space="preserve"><value>Accès partagé</value></data>
-  <data name="Auth.Login.Title" xml:space="preserve"><value>Une connexion pour tous les comptes</value></data>
-  <data name="Auth.Login.Description" xml:space="preserve"><value>Connectez-vous avec votre nom d'utilisateur ou votre courriel configuré.</value></data>
+  <data name="Auth.Login.Kicker" xml:space="preserve"><value>Espace employé</value></data>
+  <data name="Auth.Login.Title" xml:space="preserve"><value>Connectez-vous pour continuer</value></data>
+  <data name="Auth.Login.Description" xml:space="preserve"><value>Utilisez votre compte employé ou administrateur pour accéder à l'application.</value></data>
   <data name="Auth.Login.Identifier.Label" xml:space="preserve"><value>Nom d'utilisateur ou courriel</value></data>
   <data name="Auth.Login.Identifier.Placeholder" xml:space="preserve"><value>Saisissez votre nom d'utilisateur ou votre courriel</value></data>
   <data name="Auth.Login.Password.Label" xml:space="preserve"><value>Mot de passe</value></data>
@@ -20,4 +20,9 @@
   <data name="Auth.Login.Error.NotAllowed" xml:space="preserve"><value>Ce compte n'est pas encore confirmé.</value></data>
   <data name="Auth.Login.Validation.IdentifierRequired" xml:space="preserve"><value>Saisissez votre nom d'utilisateur ou votre courriel.</value></data>
   <data name="Auth.Login.Validation.PasswordRequired" xml:space="preserve"><value>Saisissez votre mot de passe.</value></data>
+  <data name="Auth.AccessDenied.PageTitle" xml:space="preserve"><value>Accès refusé</value></data>
+  <data name="Auth.AccessDenied.Kicker" xml:space="preserve"><value>Accès administrateur</value></data>
+  <data name="Auth.AccessDenied.Title" xml:space="preserve"><value>Vous n'avez pas l'autorisation de voir cette page</value></data>
+  <data name="Auth.AccessDenied.Description" xml:space="preserve"><value>Demandez à un administrateur de vous accorder l'accès requis ou retournez à l'accueil.</value></data>
+  <data name="Auth.AccessDenied.Action.Home" xml:space="preserve"><value>Retour à l'accueil</value></data>
 </root>

--- a/src/Beagl.WebApp/Resources/Resources.AuthResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.AuthResource.resx
@@ -7,9 +7,9 @@
   <data name="Auth.Login.PageTitle" xml:space="preserve"><value>Sign in</value></data>
   <data name="Auth.Login.Brand.Alt" xml:space="preserve"><value>Beagl logo</value></data>
   <data name="Auth.Login.Brand.Name" xml:space="preserve"><value>Beagl CRM</value></data>
-  <data name="Auth.Login.Kicker" xml:space="preserve"><value>Shared access</value></data>
-  <data name="Auth.Login.Title" xml:space="preserve"><value>One login for every account</value></data>
-  <data name="Auth.Login.Description" xml:space="preserve"><value>Sign in with your username or configured email address.</value></data>
+  <data name="Auth.Login.Kicker" xml:space="preserve"><value>Employee workspace</value></data>
+  <data name="Auth.Login.Title" xml:space="preserve"><value>Sign in to continue working</value></data>
+  <data name="Auth.Login.Description" xml:space="preserve"><value>Use your employee or administrator account to access the application.</value></data>
   <data name="Auth.Login.Identifier.Label" xml:space="preserve"><value>Username or email</value></data>
   <data name="Auth.Login.Identifier.Placeholder" xml:space="preserve"><value>Enter your username or email</value></data>
   <data name="Auth.Login.Password.Label" xml:space="preserve"><value>Password</value></data>
@@ -20,4 +20,9 @@
   <data name="Auth.Login.Error.NotAllowed" xml:space="preserve"><value>This account is not confirmed yet.</value></data>
   <data name="Auth.Login.Validation.IdentifierRequired" xml:space="preserve"><value>Enter your username or email.</value></data>
   <data name="Auth.Login.Validation.PasswordRequired" xml:space="preserve"><value>Enter your password.</value></data>
+  <data name="Auth.AccessDenied.PageTitle" xml:space="preserve"><value>Access denied</value></data>
+  <data name="Auth.AccessDenied.Kicker" xml:space="preserve"><value>Administrator access</value></data>
+  <data name="Auth.AccessDenied.Title" xml:space="preserve"><value>You do not have permission to view this page</value></data>
+  <data name="Auth.AccessDenied.Description" xml:space="preserve"><value>Ask an administrator to grant the required access, or return to the home page.</value></data>
+  <data name="Auth.AccessDenied.Action.Home" xml:space="preserve"><value>Return home</value></data>
 </root>

--- a/tests/Beagl.WebApp.Tests/Authentication/SharedLoginServiceTests.cs
+++ b/tests/Beagl.WebApp.Tests/Authentication/SharedLoginServiceTests.cs
@@ -1,5 +1,6 @@
 // MIT License - Copyright (c) 2025 Jonathan St-Michel
 
+using Beagl.Domain.Users;
 using Beagl.Infrastructure.Users.Entities;
 using Beagl.WebApp.Authentication;
 using FluentAssertions;
@@ -24,6 +25,7 @@ public sealed class SharedLoginServiceTests
 
         userManagerMock.Setup(manager => manager.FindByNameAsync("employee1@local"))
             .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Employee);
         signInManagerMock.Setup(manager => manager.PasswordSignInAsync(user, "StrongPassword!1", false, false))
             .ReturnsAsync(SignInResult.Success);
 
@@ -47,6 +49,7 @@ public sealed class SharedLoginServiceTests
             .ReturnsAsync((ApplicationUser?)null);
         userManagerMock.Setup(manager => manager.FindByEmailAsync("employee1@beagl.local"))
             .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Employee);
         signInManagerMock.Setup(manager => manager.PasswordSignInAsync(user, "StrongPassword!1", false, false))
             .ReturnsAsync(SignInResult.Success);
 
@@ -62,21 +65,22 @@ public sealed class SharedLoginServiceTests
     [Fact]
     public async Task AuthenticateAsync_ShouldUseUserNameLookup_WhenIdentifierIsNotEmail()
     {
-        ApplicationUser user = new() { UserName = "citizen1", Email = "citizen1@beagl.local" };
+        ApplicationUser user = new() { UserName = "employee3", Email = "employee3@beagl.local" };
         Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
         Mock<SignInManager<ApplicationUser>> signInManagerMock = CreateSignInManagerMock(userManagerMock.Object);
 
-        userManagerMock.Setup(manager => manager.FindByNameAsync("citizen1"))
+        userManagerMock.Setup(manager => manager.FindByNameAsync("employee3"))
             .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Employee);
         signInManagerMock.Setup(manager => manager.PasswordSignInAsync(user, "StrongPassword!1", true, false))
             .ReturnsAsync(SignInResult.Success);
 
         SharedLoginService service = new(userManagerMock.Object, signInManagerMock.Object);
 
-        SharedLoginStatus result = await service.AuthenticateAsync("citizen1", "StrongPassword!1", true);
+        SharedLoginStatus result = await service.AuthenticateAsync("employee3", "StrongPassword!1", true);
 
         result.Should().Be(SharedLoginStatus.Succeeded);
-        userManagerMock.Verify(manager => manager.FindByNameAsync("citizen1"), Times.Once);
+        userManagerMock.Verify(manager => manager.FindByNameAsync("employee3"), Times.Once);
         userManagerMock.Verify(manager => manager.FindByEmailAsync(It.IsAny<string>()), Times.Never);
     }
 
@@ -104,12 +108,13 @@ public sealed class SharedLoginServiceTests
     [Fact]
     public async Task AuthenticateAsync_ShouldUseUserNameLookup_WhenIdentifierLooksLikePhoneNumber()
     {
-        ApplicationUser user = new() { UserName = "+1 (555) 000-1111", Email = "citizen-phone@beagl.local" };
+        ApplicationUser user = new() { UserName = "+1 (555) 000-1111", Email = "employee-phone@beagl.local" };
         Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
         Mock<SignInManager<ApplicationUser>> signInManagerMock = CreateSignInManagerMock(userManagerMock.Object);
 
         userManagerMock.Setup(manager => manager.FindByNameAsync("+1 (555) 000-1111"))
             .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Employee);
         signInManagerMock.Setup(manager => manager.PasswordSignInAsync(user, "StrongPassword!1", false, false))
             .ReturnsAsync(SignInResult.Success);
 
@@ -131,6 +136,7 @@ public sealed class SharedLoginServiceTests
 
         userManagerMock.Setup(manager => manager.FindByNameAsync("employee2"))
             .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Employee);
         signInManagerMock.Setup(manager => manager.PasswordSignInAsync(user, "StrongPassword!1", false, false))
             .ReturnsAsync(SignInResult.LockedOut);
 
@@ -144,20 +150,42 @@ public sealed class SharedLoginServiceTests
     [Fact]
     public async Task AuthenticateAsync_ShouldReturnNotAllowed_WhenIdentityReturnsNotAllowed()
     {
-        ApplicationUser user = new() { UserName = "employee3", Email = "employee3@beagl.local" };
+        ApplicationUser user = new() { UserName = "employee4", Email = "employee4@beagl.local" };
         Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
         Mock<SignInManager<ApplicationUser>> signInManagerMock = CreateSignInManagerMock(userManagerMock.Object);
 
-        userManagerMock.Setup(manager => manager.FindByNameAsync("employee3"))
+        userManagerMock.Setup(manager => manager.FindByNameAsync("employee4"))
             .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Administrator);
         signInManagerMock.Setup(manager => manager.PasswordSignInAsync(user, "StrongPassword!1", false, false))
             .ReturnsAsync(SignInResult.NotAllowed);
 
         SharedLoginService service = new(userManagerMock.Object, signInManagerMock.Object);
 
-        SharedLoginStatus result = await service.AuthenticateAsync("employee3", "StrongPassword!1", false);
+        SharedLoginStatus result = await service.AuthenticateAsync("employee4", "StrongPassword!1", false);
 
         result.Should().Be(SharedLoginStatus.NotAllowed);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_ShouldReturnInvalidCredentials_WhenUserDoesNotHaveEmployeeAccess()
+    {
+        ApplicationUser user = new() { UserName = "citizen1", Email = "citizen1@beagl.local" };
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        Mock<SignInManager<ApplicationUser>> signInManagerMock = CreateSignInManagerMock(userManagerMock.Object);
+
+        userManagerMock.Setup(manager => manager.FindByNameAsync("citizen1"))
+            .ReturnsAsync(user);
+        SetEmployeeAccess(userManagerMock, user, UserRole.Citizen);
+
+        SharedLoginService service = new(userManagerMock.Object, signInManagerMock.Object);
+
+        SharedLoginStatus result = await service.AuthenticateAsync("citizen1", "StrongPassword!1", false);
+
+        result.Should().Be(SharedLoginStatus.InvalidCredentials);
+        signInManagerMock.Verify(
+            manager => manager.PasswordSignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()),
+            Times.Never);
     }
 
     private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
@@ -205,5 +233,16 @@ public sealed class SharedLoginServiceTests
             userConfirmationMock.Object);
 
         return signInManagerMock;
+    }
+
+    private static void SetEmployeeAccess(
+        Mock<UserManager<ApplicationUser>> userManagerMock,
+        ApplicationUser user,
+        UserRole role)
+    {
+        userManagerMock.Setup(manager => manager.IsInRoleAsync(user, nameof(UserRole.Employee)))
+            .ReturnsAsync(role == UserRole.Employee);
+        userManagerMock.Setup(manager => manager.IsInRoleAsync(user, nameof(UserRole.Administrator)))
+            .ReturnsAsync(role == UserRole.Administrator);
     }
 }

--- a/tests/Beagl.WebApp.Tests/Components/Routing/RouteAuthorizationRedirectTests.cs
+++ b/tests/Beagl.WebApp.Tests/Components/Routing/RouteAuthorizationRedirectTests.cs
@@ -1,0 +1,52 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System.Security.Claims;
+using Bunit;
+using Bunit.TestDoubles;
+using Beagl.WebApp.Components.Routing;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Beagl.WebApp.Tests.Components.Routing;
+
+public sealed class RouteAuthorizationRedirectTests : TestContext
+{
+    [Fact]
+    public void Render_ShouldRedirectAnonymousUsersToLoginWithReturnUrl()
+    {
+        Services.AddAuthorizationCore();
+        Services.AddCascadingAuthenticationState();
+
+        TestAuthorizationContext authorizationContext = this.AddTestAuthorization();
+        authorizationContext.SetNotAuthorized();
+
+        NavigationManager navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("/employee/users");
+
+        RenderComponent<CascadingAuthenticationState>(parameters => parameters
+            .AddChildContent<RouteAuthorizationRedirect>());
+
+        navigationManager.Uri.Should().Be("http://localhost/account/login?returnUrl=%2Femployee%2Fusers");
+    }
+
+    [Fact]
+    public void Render_ShouldRedirectAuthenticatedUsersToAccessDenied()
+    {
+        Services.AddAuthorizationCore();
+        Services.AddCascadingAuthenticationState();
+
+        TestAuthorizationContext authorizationContext = this.AddTestAuthorization();
+        authorizationContext.SetAuthorized("employee1");
+        authorizationContext.SetClaims(new Claim(ClaimTypes.Role, "Employee"));
+
+        NavigationManager navigationManager = Services.GetRequiredService<NavigationManager>();
+        navigationManager.NavigateTo("/employee/users");
+
+        RenderComponent<CascadingAuthenticationState>(parameters => parameters
+            .AddChildContent<RouteAuthorizationRedirect>());
+
+        navigationManager.Uri.Should().Be("http://localhost/account/access-denied");
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `EmployeeAccess` authorization policy scoped to Employee and Administrator roles
- Replaces open `RouteView` with `AuthorizeRouteView` backed by a `RouteAuthorizationRedirect` component that routes anonymous users to login and authenticated-but-unauthorized users to a dedicated access-denied page
- Restricts the shared login to Employee/Administrator accounts; citizens are rejected before sign-in is attempted
- Adds a localized `/account/access-denied` Razor Page (EN + FR) and wires it as the `AccessDeniedPath`

## Motivation
The employee workspace was publicly accessible without authentication. This change enforces that only authenticated employees and administrators can reach any route protected by the `EmployeeAccess` policy, and provides clear, localized feedback when access is denied.

## Changes
- Added `AuthorizationPolicies` static class defining `EmployeeAccess`, `EmployeeRole`, and `AdministratorRole` constants
- Added `RouteAuthorizationRedirect` Blazor component handling unauthorized navigation: anonymous → login with `returnUrl`, authenticated-not-authorized → `/account/access-denied`
- Added `AccessDenied` Razor Page (`AccessDenied.cshtml` + `AccessDeniedModel`) at `/account/access-denied`
- Applied `[Authorize(Policy = EmployeeAccess)]` to `Home.razor` and `Users.razor` (Users further scoped to Administrator role)
- Registered `AddCascadingAuthenticationState()` and `AddAuthorizationBuilder()` with the `EmployeeAccess` policy in `Program.cs`
- Updated `SharedLoginService` to reject non-employee/non-administrator accounts before calling `PasswordSignInAsync`
- Updated EN and FR localization resources: refined login copy, added five access-denied keys

## Commit Overview
- `8f5daf7` feat(webapp): require auth for employee workspace

## Architectural Impact
- Domain: N/A
- Application: N/A
- Infrastructure: N/A
- WebApp: New authorization policy registration; new routing component; new Razor Page; `[Authorize]` attributes on Blazor pages; updated `SharedLoginService` login guard

## Database / Migration
N/A

## Testing
- `SharedLoginServiceTests`: added `SetEmployeeAccess` mock helper; added `AuthenticateAsync_ShouldReturnInvalidCredentials_WhenUserDoesNotHaveEmployeeAccess`; updated existing tests to configure employee/administrator role mocks
- New `RouteAuthorizationRedirectTests` (bUnit): verifies anonymous redirect to `/account/login?returnUrl=…` and authenticated-unauthorized redirect to `/account/access-denied`
- Coverage impact: new service guard path and routing component fully exercised by new test cases

## How to validate
1. Start the application unauthenticated and navigate to `/`; confirm redirect to `/account/login?returnUrl=%2F`.
2. Sign in with a Citizen account; confirm login is rejected with invalid-credentials feedback before reaching the dashboard.
3. Sign in with an Employee account; confirm access to `/` and that `/employee/users` returns 403 for non-administrators.
4. Sign in with an Administrator account; confirm access to both `/` and `/employee/users`.
5. Trigger the access-denied path (e.g., Employee hitting `/employee/users`); confirm redirect to `/account/access-denied` with correct localized content.

## Breaking Changes
Citizens can no longer sign in through the employee workspace login page. Accounts without the Employee or Administrator role will receive an invalid-credentials response.