### PR TITLE
Generate email confirmation token on user account creation

### DIFF
--- a/src/Beagl.Application/Users/Dtos/UserDetailsDto.cs
+++ b/src/Beagl.Application/Users/Dtos/UserDetailsDto.cs
@@ -14,6 +14,7 @@ using Beagl.Domain.Users;
 /// <param name="EmailConfirmed">A value indicating whether the email address is confirmed.</param>
 /// <param name="IsLockedOut">A value indicating whether the user is currently locked out.</param>
 /// <param name="Role">The user role.</param>
+/// <param name="EmailConfirmationToken">The email confirmation token produced at account creation time.</param>
 public sealed record UserDetailsDto(
     string Id,
     string UserName,
@@ -21,4 +22,5 @@ public sealed record UserDetailsDto(
     string? PhoneNumber,
     bool EmailConfirmed,
     bool IsLockedOut,
-    UserRole Role);
+    UserRole Role,
+    string? EmailConfirmationToken = null);

--- a/src/Beagl.Application/Users/Services/UserManagementService.cs
+++ b/src/Beagl.Application/Users/Services/UserManagementService.cs
@@ -169,7 +169,8 @@ public sealed partial class UserManagementService(
             user.PhoneNumber,
             user.EmailConfirmed,
             user.IsLockedOut,
-            user.Role);
+            user.Role,
+            user.EmailConfirmationToken);
     }
 
     private static Result ValidateCreateRequest(CreateUserRequest request)

--- a/src/Beagl.Domain/Users/UserAccount.cs
+++ b/src/Beagl.Domain/Users/UserAccount.cs
@@ -12,6 +12,7 @@ namespace Beagl.Domain.Users;
 /// <param name="EmailConfirmed">A value indicating whether the email address is confirmed.</param>
 /// <param name="IsLockedOut">A value indicating whether the user is currently locked out.</param>
 /// <param name="Role">The user role.</param>
+/// <param name="EmailConfirmationToken">The email confirmation token produced at account creation time.</param>
 public sealed record UserAccount(
     string Id,
     string UserName,
@@ -19,4 +20,5 @@ public sealed record UserAccount(
     string? PhoneNumber,
     bool EmailConfirmed,
     bool IsLockedOut,
-    UserRole Role);
+    UserRole Role,
+    string? EmailConfirmationToken = null);

--- a/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
+++ b/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
@@ -143,7 +143,10 @@ public sealed class IdentityUserRepository(
             return Result.Failure<UserAccount>(MapIdentityError(addToRoleResult));
         }
 
-        return Result.Success(await MapAsync(identityUser).ConfigureAwait(false));
+        string? emailConfirmationToken = await GenerateEmailConfirmationTokenAsync(identityUser).ConfigureAwait(false);
+        UserAccount createdUser = await MapAsync(identityUser).ConfigureAwait(false);
+
+        return Result.Success(createdUser with { EmailConfirmationToken = emailConfirmationToken });
     }
 
     /// <inheritdoc />
@@ -274,6 +277,16 @@ public sealed class IdentityUserRepository(
         }
 
         return await _userManager.AddToRoleAsync(user, newRole.ToString()).ConfigureAwait(false);
+    }
+
+    private async Task<string?> GenerateEmailConfirmationTokenAsync(ApplicationUser user)
+    {
+        if (user.EmailConfirmed || string.IsNullOrWhiteSpace(user.Email))
+        {
+            return null;
+        }
+
+        return await _userManager.GenerateEmailConfirmationTokenAsync(user).ConfigureAwait(false);
     }
 
     private static ResultError MapIdentityError(IdentityResult identityResult)

--- a/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
@@ -397,7 +397,7 @@ public class UserManagementServiceTests
         Mock<IUserRepository> userRepositoryMock = new();
         userRepositoryMock
             .Setup(repository => repository.CreateAsync(It.IsAny<CreateUserAccount>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Success(new UserAccount("user-1", "alex", "alex@example.com", "+1234567890", false, false, UserRole.Employee)));
+            .ReturnsAsync(Result.Success(new UserAccount("user-1", "alex", "alex@example.com", "+1234567890", false, false, UserRole.Employee, "confirmation-token")));
 
         UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
         CreateUserRequest request = new("alex", "alex@example.com", "+1234567890", "Password123!", UserRole.Employee);
@@ -411,6 +411,7 @@ public class UserManagementServiceTests
         result.Value!.Id.Should().Be("user-1");
         result.Value.UserName.Should().Be("alex");
         result.Value.Email.Should().Be("alex@example.com");
+        result.Value.EmailConfirmationToken.Should().Be("confirmation-token");
     }
 
     [Fact]

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
@@ -54,6 +54,9 @@ public class IdentityUserRepositoryTests
             .Setup(manager => manager.AddToRoleAsync(It.IsAny<ApplicationUser>(), UserRole.Employee.ToString()))
             .ReturnsAsync(IdentityResult.Success);
         userManagerMock
+            .Setup(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()))
+            .ReturnsAsync("confirmation-token");
+        userManagerMock
             .Setup(manager => manager.GetRolesAsync(It.IsAny<ApplicationUser>()))
             .ReturnsAsync([UserRole.Employee.ToString()]);
 
@@ -72,6 +75,8 @@ public class IdentityUserRepositoryTests
         result.Value.PhoneNumber.Should().Be("555-0100");
         result.Value.EmailConfirmed.Should().BeFalse();
         result.Value.Role.Should().Be(UserRole.Employee);
+        result.Value.EmailConfirmationToken.Should().Be("confirmation-token");
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Once);
     }
 
     [Fact]
@@ -113,6 +118,8 @@ public class IdentityUserRepositoryTests
         capturedUser.Should().NotBeNull();
         capturedUser!.EmailConfirmed.Should().BeTrue();
         result.Value!.EmailConfirmed.Should().BeTrue();
+        result.Value.EmailConfirmationToken.Should().BeNull();
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
     [Theory]
@@ -145,6 +152,7 @@ public class IdentityUserRepositoryTests
         result.Error!.Code.Should().Be(expectedCode);
         result.Error.Message.Should().Be(expectedMessage);
         userManagerMock.Verify(manager => manager.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
     [Fact]
@@ -167,6 +175,7 @@ public class IdentityUserRepositoryTests
         result.Error.Should().NotBeNull();
         result.Error!.Code.Should().Be("users.identity_error");
         result.Error.Message.Should().Be("The user operation could not be completed.");
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
     [Fact]
@@ -195,6 +204,7 @@ public class IdentityUserRepositoryTests
         result.Error.Should().NotBeNull();
         result.Error!.Code.Should().Be("users.role_not_found");
         userManagerMock.Verify(manager => manager.DeleteAsync(It.IsAny<ApplicationUser>()), Times.Once);
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add an optional email confirmation token to the user creation result contract
- Generate the ASP.NET Identity email confirmation token after successful user creation and role assignment
- Propagate the token through the application service mapping for downstream confirmation delivery
- Extend unit tests to cover token generation and non-generation paths

## Motivation
Provide the confirmation token needed immediately after creating a user account so downstream confirmation delivery can proceed without changing unrelated login or UI behavior.

## Changes
- Add EmailConfirmationToken to UserAccount and UserDetailsDto as optional create-flow data
- Generate the token in IdentityUserRepository only when creation succeeds and the user is not already confirmed
- Update application and infrastructure tests to verify token propagation and skipped generation on failure paths

## Commit Overview
- a7f9212 feat(users): generate email confirmation token on user creation

## Architectural Impact
- Domain: UserAccount now carries an optional EmailConfirmationToken for create-flow results
- Application: UserManagementService maps the confirmation token into UserDetailsDto
- Infrastructure: IdentityUserRepository generates the token via ASP.NET Identity after successful persistence
- WebApp: N/A

## Database / Migration
N/A

## Testing
- Updated UserManagementServiceTests to verify confirmation token propagation
- Updated IdentityUserRepositoryTests to verify token generation on success and no generation on failure or confirmed-user paths
- Coverage impact or N/A: N/A

## How to validate
1. Create a new unconfirmed user through the managed user creation flow.
2. Verify the returned create result includes a non-empty email confirmation token.
3. Confirm that failed creation or role assignment paths do not generate a token.

## Breaking Changes
None