### PR TITLE
feat(users): allow admins to confirm unconfirmed user accounts

### DIFF
--- a/src/Beagl.Application/Users/Services/IUserManagementService.cs
+++ b/src/Beagl.Application/Users/Services/IUserManagementService.cs
@@ -56,4 +56,12 @@ public interface IUserManagementService
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The outcome of the deletion.</returns>
     public Task<Result> DeleteAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Confirms an existing user account.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The confirmed user or a failure result.</returns>
+    public Task<Result<UserDetailsDto>> ConfirmAccountAsync(string userId, CancellationToken cancellationToken);
 }

--- a/src/Beagl.Application/Users/Services/UserManagementService.cs
+++ b/src/Beagl.Application/Users/Services/UserManagementService.cs
@@ -148,6 +148,25 @@ public sealed partial class UserManagementService(
         return result;
     }
 
+    /// <inheritdoc />
+    public async Task<Result<UserDetailsDto>> ConfirmAccountAsync(string userId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Result.Failure<UserDetailsDto>(new ResultError("users.invalid_id", "A user identifier is required."));
+        }
+
+        string trimmedUserId = userId.Trim();
+        Result<UserAccount> result = await _userRepository.ConfirmAccountAsync(trimmedUserId, cancellationToken).ConfigureAwait(false);
+        if (result.IsFailure)
+        {
+            return Result.Failure<UserDetailsDto>(result.Error!);
+        }
+
+        LogUserConfirmed(_logger, trimmedUserId);
+        return Result.Success(MapDetails(result.Value!));
+    }
+
     private static UserListItemDto MapListItem(UserAccount user)
     {
         return new UserListItemDto(
@@ -275,4 +294,7 @@ public sealed partial class UserManagementService(
 
     [LoggerMessage(EventId = 1003, Level = LogLevel.Information, Message = "Deleted managed user {UserId}")]
     private static partial void LogUserDeleted(ILogger logger, string userId);
+
+    [LoggerMessage(EventId = 1004, Level = LogLevel.Information, Message = "Confirmed managed user account {UserId}")]
+    private static partial void LogUserConfirmed(ILogger logger, string userId);
 }

--- a/src/Beagl.Domain/Users/IUserRepository.cs
+++ b/src/Beagl.Domain/Users/IUserRepository.cs
@@ -62,4 +62,12 @@ public interface IUserRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The outcome of the deletion.</returns>
     public Task<Result> DeleteAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Confirms an existing user account.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The confirmed user or a failure result.</returns>
+    public Task<Result<UserAccount>> ConfirmAccountAsync(string userId, CancellationToken cancellationToken);
 }

--- a/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
+++ b/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
@@ -200,6 +200,31 @@ public sealed class IdentityUserRepository(
         return Result.Success();
     }
 
+    /// <inheritdoc />
+    public async Task<Result<UserAccount>> ConfirmAccountAsync(string userId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? identityUser = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        if (identityUser is null)
+        {
+            return Result.Failure<UserAccount>(new ResultError("users.not_found", "The requested user could not be found."));
+        }
+
+        if (!identityUser.EmailConfirmed)
+        {
+            identityUser.EmailConfirmed = true;
+
+            IdentityResult updateResult = await _userManager.UpdateAsync(identityUser).ConfigureAwait(false);
+            if (!updateResult.Succeeded)
+            {
+                return Result.Failure<UserAccount>(MapIdentityError(updateResult));
+            }
+        }
+
+        return Result.Success(await MapAsync(identityUser).ConfigureAwait(false));
+    }
+
     private async Task<UserAccount> MapAsync(ApplicationUser user)
     {
         UserRole role = await GetPrimaryRoleAsync(user).ConfigureAwait(false);

--- a/src/Beagl.WebApp/Components/Pages/Users.razor
+++ b/src/Beagl.WebApp/Components/Pages/Users.razor
@@ -124,6 +124,19 @@
                                         </td>
                                         <td>
                                             <div class="users-actions justify-content-end">
+                                                @if (!user.EmailConfirmed)
+                                                {
+                                                    <button
+                                                        type="button"
+                                                        class="users-icon-action"
+                                                        @onclick="() => ConfirmUserAccountAsync(user.Id)"
+                                                        data-testid="confirm-@user.Id"
+                                                        aria-label='@L["Users.Action.ConfirmAccount"]'
+                                                        title='@L["Users.Action.ConfirmAccount"]'
+                                                        disabled="@_isSaving">
+                                                        <i class="bi bi-check2-circle" aria-hidden="true"></i>
+                                                    </button>
+                                                }
                                                 <button
                                                     type="button"
                                                     class="users-icon-action"
@@ -181,6 +194,18 @@
                             <h2 id="users-panel-title" class="h4 mb-1">@PanelTitle</h2>
                             <p class="text-secondary mb-0">@PanelDescription</p>
                         </div>
+                        @if (_panelMode == UserPanelMode.Details && _selectedUser is not null && !_selectedUser.EmailConfirmed)
+                        {
+                            <AuthorizeView Roles="@AuthorizationPolicies.AdministratorRole">
+                                <button
+                                    type="button"
+                                    class="btn btn-outline-success"
+                                    @onclick="ConfirmSelectedUserAccountAsync"
+                                    disabled="@_isSaving">
+                                    @L["Users.Action.ConfirmAccount"]
+                                </button>
+                            </AuthorizeView>
+                        }
                     </div>
 
                     @switch (_panelMode)
@@ -552,6 +577,50 @@
         await LoadUsersMetricsAsync().ConfigureAwait(false);
         await LoadUsersPageAsync().ConfigureAwait(false);
         _isSaving = false;
+    }
+
+    private async Task ConfirmUserAccountAsync(string userId)
+    {
+        _isSaving = true;
+        _errorMessage = null;
+        _statusMessage = null;
+
+        Result<UserDetailsDto> result = await UserManagementService
+            .ConfirmAccountAsync(userId, CancellationToken.None)
+            .ConfigureAwait(false);
+        if (result.IsFailure)
+        {
+            _errorMessage = LocalizeError(result.Error!);
+            _isSaving = false;
+            return;
+        }
+
+        if (_selectedUser is not null && _selectedUser.Id == result.Value!.Id)
+        {
+            _selectedUser = result.Value;
+        }
+
+        _statusMessage = L["Users.Success.AccountConfirmed"];
+        await LoadUsersMetricsAsync().ConfigureAwait(false);
+        await LoadUsersPageAsync().ConfigureAwait(false);
+        _isSaving = false;
+    }
+
+    private async Task ConfirmSelectedUserAccountAsync()
+    {
+        if (_selectedUser is null)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        _errorMessage = null;
+        _statusMessage = null;
+
+        Result<UserDetailsDto> result = await UserManagementService
+            .ConfirmAccountAsync(_selectedUser.Id, CancellationToken.None)
+            .ConfigureAwait(false);
+        await HandleMutationResultAsync(result, L["Users.Success.AccountConfirmed"], UserPanelMode.Details).ConfigureAwait(false);
     }
 
     private async Task<bool> LoadSelectedUserAsync(string userId, UserPanelMode panelMode)

--- a/src/Beagl.WebApp/Resources/Resources.UsersResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.UsersResource.fr.resx
@@ -37,6 +37,7 @@
   <data name="Users.Action.Delete" xml:space="preserve"><value>Supprimer</value></data>
   <data name="Users.Action.EditUser" xml:space="preserve"><value>Modifier l'utilisateur</value></data>
   <data name="Users.Action.DeleteUser" xml:space="preserve"><value>Supprimer l'utilisateur</value></data>
+  <data name="Users.Action.ConfirmAccount" xml:space="preserve"><value>Confirmer le compte</value></data>
   <data name="Users.Action.Close" xml:space="preserve"><value>Fermer</value></data>
   <data name="Users.Panel.Kicker" xml:space="preserve"><value>Espace de travail</value></data>
   <data name="Users.Form.UserName" xml:space="preserve"><value>Nom d'utilisateur</value></data>
@@ -72,6 +73,7 @@
   <data name="Users.Success.Created" xml:space="preserve"><value>Utilisateur créé avec succès.</value></data>
   <data name="Users.Success.Updated" xml:space="preserve"><value>Utilisateur mis à jour avec succès.</value></data>
   <data name="Users.Success.Deleted" xml:space="preserve"><value>Utilisateur supprimé avec succès.</value></data>
+  <data name="Users.Success.AccountConfirmed" xml:space="preserve"><value>Compte utilisateur confirmé avec succès.</value></data>
   <data name="Users.Optional.NotProvided" xml:space="preserve"><value>Non fourni</value></data>
   <data name="users.invalid_id" xml:space="preserve"><value>Un identifiant utilisateur est requis.</value></data>
   <data name="users.not_found" xml:space="preserve"><value>L'utilisateur demandé est introuvable.</value></data>

--- a/src/Beagl.WebApp/Resources/Resources.UsersResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.UsersResource.resx
@@ -37,6 +37,7 @@
   <data name="Users.Action.Delete" xml:space="preserve"><value>Delete</value></data>
   <data name="Users.Action.EditUser" xml:space="preserve"><value>Edit user</value></data>
   <data name="Users.Action.DeleteUser" xml:space="preserve"><value>Delete user</value></data>
+  <data name="Users.Action.ConfirmAccount" xml:space="preserve"><value>Confirm account</value></data>
   <data name="Users.Action.Close" xml:space="preserve"><value>Close</value></data>
   <data name="Users.Panel.Kicker" xml:space="preserve"><value>Workspace</value></data>
   <data name="Users.Form.UserName" xml:space="preserve"><value>User name</value></data>
@@ -72,6 +73,7 @@
   <data name="Users.Success.Created" xml:space="preserve"><value>User created successfully.</value></data>
   <data name="Users.Success.Updated" xml:space="preserve"><value>User updated successfully.</value></data>
   <data name="Users.Success.Deleted" xml:space="preserve"><value>User deleted successfully.</value></data>
+  <data name="Users.Success.AccountConfirmed" xml:space="preserve"><value>User account confirmed successfully.</value></data>
   <data name="Users.Optional.NotProvided" xml:space="preserve"><value>Not provided</value></data>
   <data name="users.invalid_id" xml:space="preserve"><value>A user identifier is required.</value></data>
   <data name="users.not_found" xml:space="preserve"><value>The requested user could not be found.</value></data>

--- a/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
@@ -789,6 +789,88 @@ public class UserManagementServiceTests
     }
 
     [Fact]
+    public async Task ConfirmAccountAsync_WithMissingIdentifier_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result<UserDetailsDto> result = await service.ConfirmAccountAsync(string.Empty, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be("users.invalid_id");
+        userRepositoryMock.Verify(repository => repository.ConfirmAccountAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConfirmAccountAsync_WithWhitespaceIdentifier_ShouldTrimBeforeRepositoryCall()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.ConfirmAccountAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new UserAccount("user-1", "alex", "alex@example.com", "555-0100", true, false, UserRole.Employee)));
+
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result<UserDetailsDto> result = await service.ConfirmAccountAsync("  user-1  ", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.EmailConfirmed.Should().BeTrue();
+        userRepositoryMock.Verify(repository => repository.ConfirmAccountAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ConfirmAccountAsync_WhenRepositoryReturnsFailure_ShouldPropagateFailure()
+    {
+        // Arrange
+        ResultError expectedError = new("users.not_found", "The requested user could not be found.");
+
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.ConfirmAccountAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<UserAccount>(expectedError));
+
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result<UserDetailsDto> result = await service.ConfirmAccountAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(expectedError);
+    }
+
+    [Fact]
+    public async Task ConfirmAccountAsync_WhenSucceeds_ShouldLogAccountConfirmationWithEventId1004()
+    {
+        // Arrange
+        FakeLogger<UserManagementService> fakeLogger = new();
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.ConfirmAccountAsync("user-123", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new UserAccount("user-123", "alex", "alex@example.com", "+1234567890", true, false, UserRole.Employee)));
+
+        UserManagementService service = new(userRepositoryMock.Object, fakeLogger);
+
+        // Act
+        _ = await service.ConfirmAccountAsync("user-123", CancellationToken.None);
+
+        // Assert
+        fakeLogger.Logs.Should().NotBeEmpty();
+        fakeLogger.Logs.Should().ContainSingle(log =>
+            log.Level == LogLevel.Information
+            && log.EventId.Id == 1004
+            && log.Message.Contains("user-123"));
+    }
+
+    [Fact]
     public async Task CreateAsync_WhenSucceeds_ShouldLogUserCreatedWithEventId1001()
     {
         // Arrange

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs
@@ -230,6 +230,40 @@ public class IdentityUserRepositoryQueryTests
         user.Role.Should().Be(UserRole.None);
     }
 
+    [Fact]
+    public async Task ConfirmAccountAsync_WhenUserIsUnconfirmed_ShouldPersistConfirmedState()
+    {
+        // Arrange
+        await using EfTestHarness harness = EfTestHarness.Create();
+        await harness.SeedUsersAsync(MakeUser("u1", "alice", confirmed: false, lockedOut: false));
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await harness.Repository.ConfirmAccountAsync("u1", CancellationToken.None);
+        UserAccount? reloadedUser = await harness.Repository.GetByIdAsync("u1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.EmailConfirmed.Should().BeTrue();
+        reloadedUser.Should().NotBeNull();
+        reloadedUser!.EmailConfirmed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ConfirmAccountAsync_WhenUserIsMissing_ShouldReturnFailureResult()
+    {
+        // Arrange
+        await using EfTestHarness harness = EfTestHarness.Create();
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await harness.Repository.ConfirmAccountAsync("missing", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be("users.not_found");
+    }
+
     private static ApplicationUser MakeUser(string id, string username, bool confirmed, bool lockedOut) =>
         new()
         {

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
@@ -432,6 +432,90 @@ public class IdentityUserRepositoryTests
     }
 
     [Fact]
+    public async Task ConfirmAccountAsync_WhenUserNotFound_ShouldReturnFailureResult()
+    {
+        // Arrange
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("missing-id"))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await repository.ConfirmAccountAsync("missing-id", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be("users.not_found");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountAsync_WhenUserAlreadyConfirmed_ShouldSkipUpdate()
+    {
+        // Arrange
+        ApplicationUser identityUser = new()
+        {
+            Id = "user-1",
+            UserName = "alex",
+            Email = "alex@example.com",
+            PhoneNumber = "555-0100",
+            EmailConfirmed = true,
+        };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.GetRolesAsync(identityUser))
+            .ReturnsAsync([UserRole.Employee.ToString()]);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await repository.ConfirmAccountAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.EmailConfirmed.Should().BeTrue();
+        userManagerMock.Verify(manager => manager.UpdateAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConfirmAccountAsync_WhenUpdateFails_ShouldMapIdentityError()
+    {
+        // Arrange
+        ApplicationUser identityUser = new()
+        {
+            Id = "user-1",
+            UserName = "alex",
+            Email = "alex@example.com",
+            EmailConfirmed = false,
+        };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.UpdateAsync(identityUser))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "InvalidEmail", Description = "invalid email" }));
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await repository.ConfirmAccountAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be("users.invalid_email");
+    }
+
+    [Fact]
     public async Task GetPageAsync_ShouldMapRolesWithoutCallingUserManagerGetRolesAsync()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Introduces `ConfirmAccountAsync` across the full Clean Architecture stack (Domain → Application → Infrastructure → WebApp) so administrators can manually confirm user accounts
- Adds two UI entry points: an icon button in each unconfirmed table row and a contextual button in the user details panel header
- Provides idempotent confirmation logic via Identity's `UpdateAsync`, skipping the update when the account is already confirmed
- Adds bilingual (EN/FR) localization keys and full test coverage across Application and Infrastructure layers

## Motivation
Animal-center administrators need a way to manually confirm user accounts when the email confirmation flow cannot be completed by the user (e.g., onboarding edge cases, email delivery failures). GitHub issue #55 tracks this requirement.

## Changes
- **Domain**: Added `ConfirmAccountAsync(string userId, CancellationToken)` to `IUserRepository`
- **Application**: Added `ConfirmAccountAsync` to `IUserManagementService` and implemented it in `UserManagementService` with input validation and structured logging (EventId 1004)
- **Infrastructure**: Implemented `ConfirmAccountAsync` in `IdentityUserRepository` — finds user via `UserManager`, sets `EmailConfirmed = true`, and calls `UpdateAsync`; idempotent if already confirmed
- **WebApp**: Added table-row icon button (`bi-check2-circle`) per unconfirmed user and a text button in the details panel header; both conditionally hidden when the account is already confirmed; admin-only via `AuthorizeView`
- **Localization**: Added `Users.Action.ConfirmAccount` and `Users.Success.AccountConfirmed` in `Resources.UsersResource.resx` and `.fr.resx`

## Commit Overview
- `0c8d492` feat(users): add account confirmation functionality

## Architectural Impact
- Domain: New method on `IUserRepository` contract
- Application: New method on `IUserManagementService` contract and service implementation; new log event 1004
- Infrastructure: New `IdentityUserRepository` method using ASP.NET Core Identity's `UserManager`
- WebApp: `Users.razor` updated with two confirm entry points and a new `ConfirmUserAccountAsync` handler

## Database / Migration
N/A — `EmailConfirmed` is an existing Identity column; no schema changes required.

## Testing
- 4 unit tests added in `UserManagementServiceTests`: missing/whitespace userId, repository failure propagation, successful confirmation, and log event verification
- 3 unit tests added in `IdentityUserRepositoryTests`: user not found, already confirmed (skips update), update failure mapping
- 2 query/persistence tests added in `IdentityUserRepositoryQueryTests`: persisted confirmation via EF Core InMemory, missing user path
- Full solution: 129 tests passed, 0 failed

## How to validate
1. Log in as an administrator and navigate to the Users page.
2. Locate an unconfirmed user (checkmark icon appears to the left of the eye icon in the table row) and click the checkmark — verify the icon disappears and a success toast is shown.
3. Open the same user's details panel — verify the "Confirm account" button is no longer visible in the panel header.

## Breaking Changes
None