### PR TITLE
feat(account): add manual email confirmation flow

### DIFF
--- a/src/Beagl.Application/Users/Services/IUserManagementService.cs
+++ b/src/Beagl.Application/Users/Services/IUserManagementService.cs
@@ -64,4 +64,21 @@ public interface IUserManagementService
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The confirmed user or a failure result.</returns>
     public Task<Result<UserDetailsDto>> ConfirmAccountAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Generates an email confirmation token for the specified user.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The generated token or a failure result.</returns>
+    public Task<Result<string>> GenerateEmailConfirmationTokenAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Confirms a user account using an email confirmation token.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="token">The email confirmation token.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The outcome of the confirmation.</returns>
+    public Task<Result> ConfirmAccountByTokenAsync(string userId, string token, CancellationToken cancellationToken);
 }

--- a/src/Beagl.Application/Users/Services/UserManagementService.cs
+++ b/src/Beagl.Application/Users/Services/UserManagementService.cs
@@ -167,6 +167,52 @@ public sealed partial class UserManagementService(
         return Result.Success(MapDetails(result.Value!));
     }
 
+    /// <inheritdoc />
+    public async Task<Result<string>> GenerateEmailConfirmationTokenAsync(string userId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Result.Failure<string>(new ResultError("users.invalid_id", "A user identifier is required."));
+        }
+
+        string trimmedUserId = userId.Trim();
+        Result<string> result = await _userRepository
+            .GenerateEmailConfirmationTokenAsync(trimmedUserId, cancellationToken)
+            .ConfigureAwait(false);
+        if (result.IsFailure)
+        {
+            return result;
+        }
+
+        LogTokenGenerated(_logger, trimmedUserId);
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> ConfirmAccountByTokenAsync(string userId, string token, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return Result.Failure(new ResultError("users.invalid_id", "A user identifier is required."));
+        }
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Result.Failure(new ResultError("users.token_required", "An email confirmation token is required."));
+        }
+
+        string trimmedUserId = userId.Trim();
+        Result result = await _userRepository
+            .ConfirmAccountByTokenAsync(trimmedUserId, token, cancellationToken)
+            .ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            LogUserConfirmedByToken(_logger, trimmedUserId);
+        }
+
+        return result;
+    }
+
     private static UserListItemDto MapListItem(UserAccount user)
     {
         return new UserListItemDto(
@@ -297,4 +343,10 @@ public sealed partial class UserManagementService(
 
     [LoggerMessage(EventId = 1004, Level = LogLevel.Information, Message = "Confirmed managed user account {UserId}")]
     private static partial void LogUserConfirmed(ILogger logger, string userId);
+
+    [LoggerMessage(EventId = 1005, Level = LogLevel.Information, Message = "Generated email confirmation token for managed user {UserId}")]
+    private static partial void LogTokenGenerated(ILogger logger, string userId);
+
+    [LoggerMessage(EventId = 1006, Level = LogLevel.Information, Message = "Confirmed managed user account {UserId} by token")]
+    private static partial void LogUserConfirmedByToken(ILogger logger, string userId);
 }

--- a/src/Beagl.Domain/Users/IUserRepository.cs
+++ b/src/Beagl.Domain/Users/IUserRepository.cs
@@ -70,4 +70,21 @@ public interface IUserRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The confirmed user or a failure result.</returns>
     public Task<Result<UserAccount>> ConfirmAccountAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Generates an email confirmation token for the specified user.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The generated token or a failure result.</returns>
+    public Task<Result<string>> GenerateEmailConfirmationTokenAsync(string userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Confirms a user account using an email confirmation token.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="token">The email confirmation token.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The outcome of the confirmation.</returns>
+    public Task<Result> ConfirmAccountByTokenAsync(string userId, string token, CancellationToken cancellationToken);
 }

--- a/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
+++ b/src/Beagl.Infrastructure/Users/IdentityUserRepository.cs
@@ -225,6 +225,52 @@ public sealed class IdentityUserRepository(
         return Result.Success(await MapAsync(identityUser).ConfigureAwait(false));
     }
 
+    /// <inheritdoc />
+    public async Task<Result<string>> GenerateEmailConfirmationTokenAsync(string userId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? identityUser = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        if (identityUser is null)
+        {
+            return Result.Failure<string>(new ResultError("users.not_found", "The requested user could not be found."));
+        }
+
+        if (identityUser.EmailConfirmed)
+        {
+            return Result.Failure<string>(new ResultError("users.already_confirmed", "The account is already confirmed."));
+        }
+
+        if (string.IsNullOrWhiteSpace(identityUser.Email))
+        {
+            return Result.Failure<string>(new ResultError("users.email_required", "An email address is required."));
+        }
+
+        string token = await _userManager.GenerateEmailConfirmationTokenAsync(identityUser).ConfigureAwait(false);
+
+        return Result.Success(token);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> ConfirmAccountByTokenAsync(string userId, string token, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationUser? identityUser = await _userManager.FindByIdAsync(userId).ConfigureAwait(false);
+        if (identityUser is null)
+        {
+            return Result.Failure(new ResultError("users.not_found", "The requested user could not be found."));
+        }
+
+        IdentityResult confirmResult = await _userManager.ConfirmEmailAsync(identityUser, token).ConfigureAwait(false);
+        if (!confirmResult.Succeeded)
+        {
+            return Result.Failure(new ResultError("users.invalid_token", "The confirmation token is invalid or has expired."));
+        }
+
+        return Result.Success();
+    }
+
     private async Task<UserAccount> MapAsync(ApplicationUser user)
     {
         UserRole role = await GetPrimaryRoleAsync(user).ConfigureAwait(false);

--- a/src/Beagl.WebApp/Components/App.razor
+++ b/src/Beagl.WebApp/Components/App.razor
@@ -13,6 +13,7 @@
 </head>
 <body>
     <Routes />
+    <script src="js/interop.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 </html>

--- a/src/Beagl.WebApp/Components/Pages/Users.razor
+++ b/src/Beagl.WebApp/Components/Pages/Users.razor
@@ -3,7 +3,10 @@
 @attribute [Authorize(Policy = AuthorizationPolicies.EmployeeAccess, Roles = AuthorizationPolicies.AdministratorRole)]
 @inject IUserManagementService UserManagementService
 @inject ILogger<Users> Logger
+@using Microsoft.JSInterop
 @inject IStringLocalizer<UsersResource> L
+@inject IJSRuntime JS
+@inject NavigationManager NavigationManager
 
 <PageTitle>@L["Users.PageTitle"]</PageTitle>
 
@@ -29,6 +32,14 @@
         @if (!string.IsNullOrWhiteSpace(_errorMessage))
         {
             <div class="alert alert-danger mb-4" role="alert" aria-live="assertive">@_errorMessage</div>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(_confirmationUrl))
+        {
+            <div class="alert alert-info mb-4" role="status" aria-live="polite">
+                <span>@L["Users.Info.CopyManually"]</span>
+                <input type="text" readonly value="@_confirmationUrl" class="form-control mt-2" onfocus="this.select()" aria-label='@L["Users.Action.CopyConfirmationLink"]' />
+            </div>
         }
 
         <div class="users-metrics mb-4">
@@ -294,7 +305,31 @@
                                     <dl class="users-detail-grid">
                                         <div>
                                             <dt>@L["Users.Details.EmailConfirmation"]</dt>
-                                            <dd>@(_selectedUser.EmailConfirmed ? L["Users.Details.Confirmed"] : L["Users.Details.Pending"])</dd>
+                                            <dd>
+                                                <span class="d-inline-flex align-items-center gap-2">
+                                                    @if (_selectedUser.EmailConfirmed)
+                                                    {
+                                                        @L["Users.Details.Confirmed"]
+                                                    }
+                                                    else
+                                                    {
+                                                        @L["Users.Details.Pending"]
+                                                        @if (!string.IsNullOrWhiteSpace(_selectedUser.Email))
+                                                        {
+                                                        <button
+                                                            type="button"
+                                                            class="users-icon-action users-icon-action--inline"
+                                                            @onclick="CopyConfirmationLinkAsync"
+                                                            data-testid="copy-confirmation-link"
+                                                            aria-label='@L["Users.Action.CopyConfirmationLink"]'
+                                                            title='@L["Users.Action.CopyConfirmationLink"]'
+                                                            disabled="@_isSaving">
+                                                            <i class="bi bi-clipboard" aria-hidden="true"></i>
+                                                        </button>
+                                                        }
+                                                    }
+                                                </span>
+                                            </dd>
                                         </div>
                                         <div>
                                             <dt>@L["Users.Details.Lockout"]</dt>
@@ -397,6 +432,7 @@
     private int _lockedOutUsersCount;
     private string? _errorMessage;
     private string? _statusMessage;
+    private string? _confirmationUrl;
     private UserPanelMode _panelMode;
     private UserDetailsDto? _selectedUser;
     private EditContext _createEditContext = default!;
@@ -489,6 +525,7 @@
         _panelMode = UserPanelMode.Create;
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
     }
 
     private async Task OpenDetailsPanelAsync(string userId)
@@ -523,6 +560,7 @@
         _isSaving = true;
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
 
         CreateUserRequest request = new(
             _createForm.UserName,
@@ -540,6 +578,7 @@
         _isSaving = true;
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
 
         UpdateUserRequest request = new(
             _editForm.Id,
@@ -562,6 +601,7 @@
         _isSaving = true;
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
 
         Result result = await UserManagementService.DeleteAsync(_selectedUser.Id, CancellationToken.None).ConfigureAwait(false);
         if (result.IsFailure)
@@ -584,6 +624,7 @@
         _isSaving = true;
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
 
         Result<UserDetailsDto> result = await UserManagementService
             .ConfirmAccountAsync(userId, CancellationToken.None)
@@ -616,6 +657,7 @@
         _isSaving = true;
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
 
         Result<UserDetailsDto> result = await UserManagementService
             .ConfirmAccountAsync(_selectedUser.Id, CancellationToken.None)
@@ -623,10 +665,63 @@
         await HandleMutationResultAsync(result, L["Users.Success.AccountConfirmed"], UserPanelMode.Details).ConfigureAwait(false);
     }
 
+    private async Task CopyConfirmationLinkAsync()
+    {
+        if (_selectedUser is null || _selectedUser.EmailConfirmed)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        _errorMessage = null;
+        _statusMessage = null;
+        _confirmationUrl = null;
+
+        Result<string> result = await UserManagementService
+            .GenerateEmailConfirmationTokenAsync(_selectedUser.Id, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            _panelMode = UserPanelMode.None;
+            _errorMessage = LocalizeError(result.Error!);
+            _isSaving = false;
+            return;
+        }
+
+        string confirmationUrl = NavigationManager.ToAbsoluteUri(
+            $"/account/confirm-email?userId={Uri.EscapeDataString(_selectedUser.Id)}&token={Uri.EscapeDataString(result.Value!)}").ToString();
+
+        _confirmationUrl = null;
+
+        try
+        {
+            bool copied = await JS.InvokeAsync<bool>("beagl.copyToClipboard", confirmationUrl).ConfigureAwait(false);
+
+            if (copied)
+            {
+                _statusMessage = L["Users.Success.ConfirmationLinkCopied"];
+            }
+            else
+            {
+                _confirmationUrl = confirmationUrl;
+            }
+        }
+        catch (Exception exception)
+        {
+            Logger.LogWarning(exception, "Clipboard write failed");
+            _confirmationUrl = confirmationUrl;
+        }
+
+        _panelMode = UserPanelMode.None;
+        _isSaving = false;
+    }
+
     private async Task<bool> LoadSelectedUserAsync(string userId, UserPanelMode panelMode)
     {
         _errorMessage = null;
         _statusMessage = null;
+        _confirmationUrl = null;
 
         Result<UserDetailsDto> result = await UserManagementService.GetUserByIdAsync(userId, CancellationToken.None).ConfigureAwait(false);
         if (result.IsFailure)

--- a/src/Beagl.WebApp/Pages/Account/ConfirmEmail.cshtml
+++ b/src/Beagl.WebApp/Pages/Account/ConfirmEmail.cshtml
@@ -1,0 +1,58 @@
+@page "/account/confirm-email"
+@model Beagl.WebApp.Pages.Account.ConfirmEmailModel
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Beagl.WebApp.Resources.AuthResource> L
+@{
+    ViewData["Title"] = L["Auth.ConfirmEmail.PageTitle"];
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap-icons/font/bootstrap-icons.css" />
+    <link rel="stylesheet" href="~/app.css" />
+    <link rel="stylesheet" href="~/Beagl.WebApp.styles.css" />
+</head>
+<body>
+    <section class="auth-page-shell" aria-label="@L["Auth.ConfirmEmail.PageTitle"]">
+        <article class="auth-card">
+            <a class="app-shell__brand text-decoration-none mb-3" href="/">
+                <span class="app-shell__brand-mark">
+                    <img class="app-shell__brand-logo" src="~/images/beagl_logo.png" alt="@L["Auth.Login.Brand.Alt"]" />
+                </span>
+                <span>@L["Auth.Login.Brand.Name"]</span>
+            </a>
+            <p class="auth-kicker">@L["Auth.ConfirmEmail.Kicker"]</p>
+            <h1 class="auth-heading">@L["Auth.ConfirmEmail.Title"]</h1>
+
+            @if (Model.IsSuccess)
+            {
+                <div class="alert alert-success" role="status" aria-live="polite">
+                    <i class="bi bi-check-circle me-2" aria-hidden="true"></i>
+                    @Model.StatusMessage
+                </div>
+                <div class="auth-actions">
+                    <a class="btn btn-primary px-4" href="/account/login">@L["Auth.ConfirmEmail.Action.Login"]</a>
+                </div>
+            }
+            else if (Model.IsError)
+            {
+                <div class="alert alert-danger" role="alert" aria-live="assertive">
+                    <i class="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>
+                    @Model.StatusMessage
+                </div>
+                <div class="auth-actions">
+                    <a class="btn btn-primary px-4" href="/">@L["Auth.ConfirmEmail.Action.Home"]</a>
+                </div>
+            }
+            else
+            {
+                <p class="auth-copy">@L["Auth.ConfirmEmail.Description"]</p>
+            }
+        </article>
+    </section>
+</body>
+</html>

--- a/src/Beagl.WebApp/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/src/Beagl.WebApp/Pages/Account/ConfirmEmail.cshtml.cs
@@ -1,0 +1,66 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Users.Services;
+using Beagl.Domain.Results;
+using Beagl.WebApp.Resources;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Localization;
+
+namespace Beagl.WebApp.Pages.Account;
+
+/// <summary>
+/// Handles email confirmation using a token-based flow.
+/// </summary>
+[AllowAnonymous]
+internal sealed class ConfirmEmailModel(
+    IUserManagementService userManagementService,
+    IStringLocalizer<AuthResource> localizer) : PageModel
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the confirmation succeeded.
+    /// </summary>
+    public bool IsSuccess { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an error occurred.
+    /// </summary>
+    public bool IsError { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status message to display.
+    /// </summary>
+    public string StatusMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Processes the email confirmation request.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="token">The email confirmation token.</param>
+    /// <returns>The page result.</returns>
+    public async Task<IActionResult> OnGetAsync(string? userId, string? token)
+    {
+        if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(token))
+        {
+            IsError = true;
+            StatusMessage = localizer["Auth.ConfirmEmail.Error.MissingToken"];
+            return Page();
+        }
+
+        Result result = await userManagementService
+            .ConfirmAccountByTokenAsync(userId, token, HttpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            IsError = true;
+            StatusMessage = localizer["Auth.ConfirmEmail.Error.Failed"];
+            return Page();
+        }
+
+        IsSuccess = true;
+        StatusMessage = localizer["Auth.ConfirmEmail.Success"];
+        return Page();
+    }
+}

--- a/src/Beagl.WebApp/Resources/Resources.AuthResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.AuthResource.fr.resx
@@ -25,4 +25,13 @@
   <data name="Auth.AccessDenied.Title" xml:space="preserve"><value>Vous n'avez pas l'autorisation de voir cette page</value></data>
   <data name="Auth.AccessDenied.Description" xml:space="preserve"><value>Demandez à un administrateur de vous accorder l'accès requis ou retournez à l'accueil.</value></data>
   <data name="Auth.AccessDenied.Action.Home" xml:space="preserve"><value>Retour à l'accueil</value></data>
+  <data name="Auth.ConfirmEmail.PageTitle" xml:space="preserve"><value>Confirmation du courriel</value></data>
+  <data name="Auth.ConfirmEmail.Kicker" xml:space="preserve"><value>Vérification du compte</value></data>
+  <data name="Auth.ConfirmEmail.Title" xml:space="preserve"><value>Confirmez votre adresse courriel</value></data>
+  <data name="Auth.ConfirmEmail.Description" xml:space="preserve"><value>Votre adresse courriel est en cours de vérification.</value></data>
+  <data name="Auth.ConfirmEmail.Success" xml:space="preserve"><value>Votre adresse courriel a été confirmée. Vous pouvez maintenant vous connecter.</value></data>
+  <data name="Auth.ConfirmEmail.Error.MissingToken" xml:space="preserve"><value>Le lien de confirmation est incomplet. Un jeton valide est requis.</value></data>
+  <data name="Auth.ConfirmEmail.Error.Failed" xml:space="preserve"><value>Le jeton de confirmation est invalide ou a expiré.</value></data>
+  <data name="Auth.ConfirmEmail.Action.Login" xml:space="preserve"><value>Aller à la connexion</value></data>
+  <data name="Auth.ConfirmEmail.Action.Home" xml:space="preserve"><value>Retour à l'accueil</value></data>
 </root>

--- a/src/Beagl.WebApp/Resources/Resources.AuthResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.AuthResource.resx
@@ -25,4 +25,13 @@
   <data name="Auth.AccessDenied.Title" xml:space="preserve"><value>You do not have permission to view this page</value></data>
   <data name="Auth.AccessDenied.Description" xml:space="preserve"><value>Ask an administrator to grant the required access, or return to the home page.</value></data>
   <data name="Auth.AccessDenied.Action.Home" xml:space="preserve"><value>Return home</value></data>
+  <data name="Auth.ConfirmEmail.PageTitle" xml:space="preserve"><value>Email confirmation</value></data>
+  <data name="Auth.ConfirmEmail.Kicker" xml:space="preserve"><value>Account verification</value></data>
+  <data name="Auth.ConfirmEmail.Title" xml:space="preserve"><value>Confirm your email address</value></data>
+  <data name="Auth.ConfirmEmail.Description" xml:space="preserve"><value>Your email address is being verified.</value></data>
+  <data name="Auth.ConfirmEmail.Success" xml:space="preserve"><value>Your email address has been confirmed. You can now sign in.</value></data>
+  <data name="Auth.ConfirmEmail.Error.MissingToken" xml:space="preserve"><value>The confirmation link is incomplete. A valid token is required.</value></data>
+  <data name="Auth.ConfirmEmail.Error.Failed" xml:space="preserve"><value>The confirmation token is invalid or has expired.</value></data>
+  <data name="Auth.ConfirmEmail.Action.Login" xml:space="preserve"><value>Go to sign in</value></data>
+  <data name="Auth.ConfirmEmail.Action.Home" xml:space="preserve"><value>Return home</value></data>
 </root>

--- a/src/Beagl.WebApp/Resources/Resources.UsersResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.UsersResource.fr.resx
@@ -92,4 +92,10 @@
   <data name="users.role_not_found" xml:space="preserve"><value>Le rôle demandé n'existe pas.</value></data>
   <data name="users.duplicate_user_name" xml:space="preserve"><value>Le nom d'utilisateur est déjà utilisé.</value></data>
   <data name="users.duplicate_email" xml:space="preserve"><value>L'adresse courriel est déjà utilisée.</value></data>
+  <data name="users.already_confirmed" xml:space="preserve"><value>Le compte est déjà confirmé.</value></data>
+  <data name="users.token_required" xml:space="preserve"><value>Un jeton de confirmation de courriel est requis.</value></data>
+  <data name="users.invalid_token" xml:space="preserve"><value>Le jeton de confirmation est invalide ou a expiré.</value></data>
+  <data name="Users.Action.CopyConfirmationLink" xml:space="preserve"><value>Copier le lien de confirmation</value></data>
+  <data name="Users.Success.ConfirmationLinkCopied" xml:space="preserve"><value>Lien de confirmation copié dans le presse-papiers.</value></data>
+  <data name="Users.Info.CopyManually" xml:space="preserve"><value>Impossible de copier automatiquement. Sélectionnez le lien ci-dessous et copiez-le manuellement.</value></data>
 </root>

--- a/src/Beagl.WebApp/Resources/Resources.UsersResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.UsersResource.resx
@@ -92,4 +92,10 @@
   <data name="users.role_not_found" xml:space="preserve"><value>The requested role does not exist.</value></data>
   <data name="users.duplicate_user_name" xml:space="preserve"><value>The user name is already in use.</value></data>
   <data name="users.duplicate_email" xml:space="preserve"><value>The email address is already in use.</value></data>
+  <data name="users.already_confirmed" xml:space="preserve"><value>The account is already confirmed.</value></data>
+  <data name="users.token_required" xml:space="preserve"><value>An email confirmation token is required.</value></data>
+  <data name="users.invalid_token" xml:space="preserve"><value>The confirmation token is invalid or has expired.</value></data>
+  <data name="Users.Action.CopyConfirmationLink" xml:space="preserve"><value>Copy confirmation link</value></data>
+  <data name="Users.Success.ConfirmationLinkCopied" xml:space="preserve"><value>Confirmation link copied to clipboard.</value></data>
+  <data name="Users.Info.CopyManually" xml:space="preserve"><value>Could not copy automatically. Select the link below and copy it manually.</value></data>
 </root>

--- a/src/Beagl.WebApp/wwwroot/js/interop.js
+++ b/src/Beagl.WebApp/wwwroot/js/interop.js
@@ -1,0 +1,41 @@
+/**
+ * Beagl interop helpers for Blazor Server.
+ */
+window.beagl = {
+    /**
+     * Attempts to copy text to the clipboard.
+     * Returns true on success, false when the browser blocks the operation.
+     * @param {string} text - The text to copy.
+     * @returns {Promise<boolean>}
+     */
+    copyToClipboard: async function (text) {
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                return true;
+            }
+
+            const textarea = document.createElement("textarea");
+            textarea.value = text;
+            textarea.style.position = "fixed";
+            textarea.style.left = "-9999px";
+            document.body.appendChild(textarea);
+            textarea.select();
+            const ok = document.execCommand("copy");
+            document.body.removeChild(textarea);
+            return ok;
+        } catch {
+            return false;
+        }
+    },
+
+    /**
+     * Selects all text inside an input element.
+     * @param {HTMLInputElement} element - The input element.
+     */
+    selectAll: function (element) {
+        if (element && element.select) {
+            element.select();
+        }
+    }
+};

--- a/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
@@ -940,4 +940,127 @@ public class UserManagementServiceTests
             && log.EventId.Id == 1003
             && log.Message.Contains("user-789"));
     }
+
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WithEmptyUserId_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result<string> result = await service.GenerateEmailConfirmationTokenAsync(" ", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.invalid_id");
+        userRepositoryMock.Verify(
+            repository => repository.GenerateEmailConfirmationTokenAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenRepositorySucceeds_ShouldReturnToken()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.GenerateEmailConfirmationTokenAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("generated-token"));
+
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result<string> result = await service.GenerateEmailConfirmationTokenAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("generated-token");
+    }
+
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenRepositoryFails_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.GenerateEmailConfirmationTokenAsync("user-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<string>(new ResultError("users.already_confirmed", "The account is already confirmed.")));
+
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result<string> result = await service.GenerateEmailConfirmationTokenAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.already_confirmed");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WithEmptyUserId_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result result = await service.ConfirmAccountByTokenAsync(" ", "some-token", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.invalid_id");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WithEmptyToken_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result result = await service.ConfirmAccountByTokenAsync("user-1", " ", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.token_required");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WhenRepositorySucceeds_ShouldReturnSuccess()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.ConfirmAccountByTokenAsync("user-1", "valid-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result result = await service.ConfirmAccountByTokenAsync("user-1", "valid-token", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WhenRepositoryFails_ShouldReturnFailure()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.ConfirmAccountByTokenAsync("user-1", "bad-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(new ResultError("users.invalid_token", "The confirmation token is invalid or has expired.")));
+
+        UserManagementService service = new(userRepositoryMock.Object, NullLogger<UserManagementService>.Instance);
+
+        // Act
+        Result result = await service.ConfirmAccountByTokenAsync("user-1", "bad-token", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.invalid_token");
+    }
 }

--- a/tests/Beagl.Application.Tests/coverage.runsettings
+++ b/tests/Beagl.Application.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/tests/Beagl.Domain.Tests/coverage.runsettings
+++ b/tests/Beagl.Domain.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryQueryTests.cs
@@ -264,6 +264,41 @@ public class IdentityUserRepositoryQueryTests
         result.Error!.Code.Should().Be("users.not_found");
     }
 
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenUserIsUnconfirmedWithEmail_ShouldReturnToken()
+    {
+        // Arrange
+        await using EfTestHarness harness = EfTestHarness.Create();
+        await harness.SeedUsersAsync(MakeUser("u1", "alice", confirmed: false, lockedOut: false));
+
+        // Act
+        Beagl.Domain.Results.Result<string> result = await harness.Repository.GenerateEmailConfirmationTokenAsync("u1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WhenTokenIsValid_ShouldConfirmUserAndReturnSuccess()
+    {
+        // Arrange
+        await using EfTestHarness harness = EfTestHarness.Create();
+        await harness.SeedUsersAsync(MakeUser("u1", "alice", confirmed: false, lockedOut: false));
+
+        Beagl.Domain.Results.Result<string> tokenResult = await harness.Repository.GenerateEmailConfirmationTokenAsync("u1", CancellationToken.None);
+        tokenResult.IsSuccess.Should().BeTrue();
+
+        // Act
+        Beagl.Domain.Results.Result result = await harness.Repository.ConfirmAccountByTokenAsync("u1", tokenResult.Value!, CancellationToken.None);
+        UserAccount? reloadedUser = await harness.Repository.GetByIdAsync("u1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        reloadedUser.Should().NotBeNull();
+        reloadedUser!.EmailConfirmed.Should().BeTrue();
+    }
+
     private static ApplicationUser MakeUser(string id, string username, bool confirmed, bool lockedOut) =>
         new()
         {
@@ -314,6 +349,8 @@ public class IdentityUserRepositoryQueryTests
                 new Mock<IServiceProvider>().Object,
                 new Logger<UserManager<ApplicationUser>>(new LoggerFactory()));
 
+            userManager.RegisterTokenProvider(TokenOptions.DefaultProvider, new FakeEmailTokenProvider());
+
             return new EfTestHarness(context, userManager);
         }
 
@@ -339,6 +376,18 @@ public class IdentityUserRepositoryQueryTests
         {
             _userManager.Dispose();
             await _context.DisposeAsync();
+        }
+
+        private sealed class FakeEmailTokenProvider : IUserTwoFactorTokenProvider<ApplicationUser>
+        {
+            public Task<string> GenerateAsync(string purpose, UserManager<ApplicationUser> manager, ApplicationUser user)
+                => Task.FromResult($"{user.Id}:{purpose}");
+
+            public Task<bool> ValidateAsync(string purpose, string token, UserManager<ApplicationUser> manager, ApplicationUser user)
+                => Task.FromResult(token == $"{user.Id}:{purpose}");
+
+            public Task<bool> CanGenerateTwoFactorTokenAsync(UserManager<ApplicationUser> manager, ApplicationUser user)
+                => Task.FromResult(false);
         }
     }
 }

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
@@ -569,6 +569,194 @@ public class IdentityUserRepositoryTests
         userManagerMock.Verify(manager => manager.GetRolesAsync(It.IsAny<ApplicationUser>()), Times.Never);
     }
 
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenUserNotFound_ShouldReturnNotFoundError()
+    {
+        // Arrange
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("missing-id"))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<string> result = await repository.GenerateEmailConfirmationTokenAsync("missing-id", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be("users.not_found");
+    }
+
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenUserAlreadyConfirmed_ShouldReturnAlreadyConfirmedError()
+    {
+        // Arrange
+        ApplicationUser identityUser = new() { Id = "user-1", UserName = "alex", Email = "alex@example.com", EmailConfirmed = true };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<string> result = await repository.GenerateEmailConfirmationTokenAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.already_confirmed");
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenUserHasNoEmail_ShouldReturnEmailRequiredError()
+    {
+        // Arrange
+        ApplicationUser identityUser = new() { Id = "user-1", UserName = "alex", Email = null, EmailConfirmed = false };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<string> result = await repository.GenerateEmailConfirmationTokenAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.email_required");
+        userManagerMock.Verify(manager => manager.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateEmailConfirmationTokenAsync_WhenSucceeds_ShouldReturnToken()
+    {
+        // Arrange
+        ApplicationUser identityUser = new() { Id = "user-1", UserName = "alex", Email = "alex@example.com", EmailConfirmed = false };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.GenerateEmailConfirmationTokenAsync(identityUser))
+            .ReturnsAsync("confirmation-token-123");
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result<string> result = await repository.GenerateEmailConfirmationTokenAsync("user-1", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("confirmation-token-123");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WhenUserNotFound_ShouldReturnNotFoundError()
+    {
+        // Arrange
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("missing-id"))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result result = await repository.ConfirmAccountByTokenAsync("missing-id", "some-token", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.not_found");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WhenTokenIsInvalid_ShouldReturnInvalidTokenError()
+    {
+        // Arrange
+        ApplicationUser identityUser = new() { Id = "user-1", UserName = "alex", Email = "alex@example.com", EmailConfirmed = false };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.ConfirmEmailAsync(identityUser, "bad-token"))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "InvalidToken", Description = "Invalid token." }));
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result result = await repository.ConfirmAccountByTokenAsync("user-1", "bad-token", CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("users.invalid_token");
+    }
+
+    [Fact]
+    public async Task ConfirmAccountByTokenAsync_WhenTokenIsValid_ShouldReturnSuccess()
+    {
+        // Arrange
+        ApplicationUser identityUser = new() { Id = "user-1", UserName = "alex", Email = "alex@example.com", EmailConfirmed = false };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.ConfirmEmailAsync(identityUser, "valid-token"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        Beagl.Domain.Results.Result result = await repository.ConfirmAccountByTokenAsync("user-1", "valid-token", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenUserHasNoExistingRoles_ShouldSkipRemoveFromRolesAndAddNewRole()
+    {
+        // Arrange
+        ApplicationUser identityUser = new() { Id = "user-1", UserName = "alex", Email = "alex@example.com", PhoneNumber = "555-0100" };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByIdAsync("user-1"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.UpdateAsync(identityUser))
+            .ReturnsAsync(IdentityResult.Success);
+        userManagerMock
+            .SetupSequence(manager => manager.GetRolesAsync(identityUser))
+            .ReturnsAsync([])
+            .ReturnsAsync([UserRole.Employee.ToString()]);
+        userManagerMock
+            .Setup(manager => manager.AddToRoleAsync(identityUser, UserRole.Employee.ToString()))
+            .ReturnsAsync(IdentityResult.Success);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+        UpdateUserAccount request = new("user-1", "alex", "alex@example.com", "555-0100", UserRole.Employee);
+
+        // Act
+        Beagl.Domain.Results.Result<UserAccount> result = await repository.UpdateAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Role.Should().Be(UserRole.Employee);
+        userManagerMock.Verify(manager => manager.RemoveFromRolesAsync(It.IsAny<ApplicationUser>(), It.IsAny<IEnumerable<string>>()), Times.Never);
+        userManagerMock.Verify(manager => manager.AddToRoleAsync(identityUser, UserRole.Employee.ToString()), Times.Once);
+    }
+
     private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
     {
         Mock<IUserStore<ApplicationUser>> userStoreMock = new();

--- a/tests/Beagl.Infrastructure.Tests/coverage.runsettings
+++ b/tests/Beagl.Infrastructure.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/tests/Beagl.WebApp.Tests/Pages/Account/ConfirmEmailModelTests.cs
+++ b/tests/Beagl.WebApp.Tests/Pages/Account/ConfirmEmailModelTests.cs
@@ -1,0 +1,153 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Users.Services;
+using Beagl.Domain.Results;
+using Beagl.WebApp.Pages.Account;
+using Beagl.WebApp.Resources;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using Moq;
+using System.Globalization;
+
+namespace Beagl.WebApp.Tests.Pages.Account;
+
+public sealed class ConfirmEmailModelTests
+{
+    [Fact]
+    public async Task OnGetAsync_WithMissingUserId_ShouldShowError()
+    {
+        // Arrange
+        ConfirmEmailModel model = CreateModel(out Mock<IUserManagementService> _);
+
+        // Act
+        IActionResult result = await model.OnGetAsync(null, "some-token");
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        model.IsError.Should().BeTrue();
+        model.IsSuccess.Should().BeFalse();
+        model.StatusMessage.Should().Be("Auth.ConfirmEmail.Error.MissingToken");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithMissingToken_ShouldShowError()
+    {
+        // Arrange
+        ConfirmEmailModel model = CreateModel(out Mock<IUserManagementService> _);
+
+        // Act
+        IActionResult result = await model.OnGetAsync("user-1", null);
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        model.IsError.Should().BeTrue();
+        model.IsSuccess.Should().BeFalse();
+        model.StatusMessage.Should().Be("Auth.ConfirmEmail.Error.MissingToken");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WithEmptyToken_ShouldShowError()
+    {
+        // Arrange
+        ConfirmEmailModel model = CreateModel(out Mock<IUserManagementService> _);
+
+        // Act
+        IActionResult result = await model.OnGetAsync("user-1", " ");
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        model.IsError.Should().BeTrue();
+        model.StatusMessage.Should().Be("Auth.ConfirmEmail.Error.MissingToken");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WhenConfirmationSucceeds_ShouldShowSuccess()
+    {
+        // Arrange
+        ConfirmEmailModel model = CreateModel(out Mock<IUserManagementService> serviceMock);
+        serviceMock
+            .Setup(service => service.ConfirmAccountByTokenAsync("user-1", "valid-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        IActionResult result = await model.OnGetAsync("user-1", "valid-token");
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        model.IsSuccess.Should().BeTrue();
+        model.IsError.Should().BeFalse();
+        model.StatusMessage.Should().Be("Auth.ConfirmEmail.Success");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_WhenConfirmationFails_ShouldShowError()
+    {
+        // Arrange
+        ConfirmEmailModel model = CreateModel(out Mock<IUserManagementService> serviceMock);
+        serviceMock
+            .Setup(service => service.ConfirmAccountByTokenAsync("user-1", "bad-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(new ResultError("users.invalid_token", "The confirmation token is invalid or has expired.")));
+
+        // Act
+        IActionResult result = await model.OnGetAsync("user-1", "bad-token");
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        model.IsError.Should().BeTrue();
+        model.IsSuccess.Should().BeFalse();
+        model.StatusMessage.Should().Be("Auth.ConfirmEmail.Error.Failed");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_ShouldNotCallService_WhenParametersAreMissing()
+    {
+        // Arrange
+        ConfirmEmailModel model = CreateModel(out Mock<IUserManagementService> serviceMock);
+
+        // Act
+        await model.OnGetAsync(null, null);
+
+        // Assert
+        serviceMock.Verify(
+            service => service.ConfirmAccountByTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static ConfirmEmailModel CreateModel(out Mock<IUserManagementService> serviceMock)
+    {
+        serviceMock = new Mock<IUserManagementService>();
+        TestLocalizer localizer = new();
+
+        ConfirmEmailModel model = new(serviceMock.Object, localizer)
+        {
+            PageContext = new PageContext(
+                new ActionContext(
+                    new DefaultHttpContext(),
+                    new RouteData(),
+                    new ActionDescriptor(),
+                    new ModelStateDictionary())),
+        };
+
+        return model;
+    }
+
+    private sealed class TestLocalizer : IStringLocalizer<AuthResource>
+    {
+        public LocalizedString this[string name] => new(name, name);
+
+        public LocalizedString this[string name, params object[] arguments] =>
+            new(name, string.Format(CultureInfo.InvariantCulture, name, arguments));
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
+        {
+            return [];
+        }
+    }
+}

--- a/tests/Beagl.WebApp.Tests/coverage.runsettings
+++ b/tests/Beagl.WebApp.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/Components/**/*.razor</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/Components/**/*.razor,**/*.g.cs,**/*.b.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
A manual email confirmation flow has been implemented for user accounts, including a hidden confirmation page that accepts an email confirmation token. The page displays appropriate messages based on the token's validity and allows users to confirm their accounts. Additionally, the user management service has been enhanced to generate confirmation tokens, which can be copied to the clipboard from the user detail view. Tests have been added to ensure the functionality works as expected, and localization resources have been updated accordingly.

Fixes #59