### PR TITLE
Add null checks for constructors in services tests

### DIFF
--- a/tests/Beagl.Application.Tests/Setup/Services/InitialSetupServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Setup/Services/InitialSetupServiceTests.cs
@@ -141,6 +141,26 @@ public class InitialSetupServiceTests
         capturedCreateUser.EmailConfirmed.Should().BeTrue();
     }
 
+    [Fact]
+    public void Constructor_WithNullUserRepository_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new InitialSetupService(null!, new SetupStatusCache());
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullSetupStatusCache_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new InitialSetupService(new Mock<IUserRepository>().Object, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
     [Theory]
     [InlineData("", "admin@example.com", "Password123!", "setup.user_name_required")]
     [InlineData("admin", "", "Password123!", "setup.email_required")]

--- a/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Users/Services/UserManagementServiceTests.cs
@@ -16,6 +16,81 @@ namespace Beagl.Application.Tests.Users.Services;
 public class UserManagementServiceTests
 {
     [Fact]
+    public void Constructor_WithNullUserRepository_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new UserManagementService(
+            null!,
+            new Mock<ICitizenProfileRepository>().Object,
+            new Mock<IEmailSender>().Object,
+            new Mock<IEmailTemplateService>().Object,
+            NullLogger<UserManagementService>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullCitizenProfileRepository_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new UserManagementService(
+            new Mock<IUserRepository>().Object,
+            null!,
+            new Mock<IEmailSender>().Object,
+            new Mock<IEmailTemplateService>().Object,
+            NullLogger<UserManagementService>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullEmailSender_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new UserManagementService(
+            new Mock<IUserRepository>().Object,
+            new Mock<ICitizenProfileRepository>().Object,
+            null!,
+            new Mock<IEmailTemplateService>().Object,
+            NullLogger<UserManagementService>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullEmailTemplateService_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new UserManagementService(
+            new Mock<IUserRepository>().Object,
+            new Mock<ICitizenProfileRepository>().Object,
+            new Mock<IEmailSender>().Object,
+            null!,
+            NullLogger<UserManagementService>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new UserManagementService(
+            new Mock<IUserRepository>().Object,
+            new Mock<ICitizenProfileRepository>().Object,
+            new Mock<IEmailSender>().Object,
+            new Mock<IEmailTemplateService>().Object,
+            null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
     public async Task CreateAsync_WithNullRequest_ShouldThrowArgumentNullException()
     {
         // Arrange
@@ -1808,5 +1883,30 @@ public class UserManagementServiceTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         userRepositoryMock.Verify(repository => repository.UnlockUserAsync("user-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ForCitizenWithNullEmail_ShouldNotRequireEmailAndSucceed()
+    {
+        // Arrange
+        Mock<IUserRepository> userRepositoryMock = new();
+        userRepositoryMock
+            .Setup(repository => repository.UpdateAsync(It.IsAny<UpdateUserAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new UserAccount("user-1", "citizen", string.Empty, "555-0100", false, false, UserRole.Citizen)));
+
+        Mock<ICitizenProfileRepository> citizenProfileRepositoryMock = new();
+        Mock<IEmailSender> emailSenderMock = new();
+        Mock<IEmailTemplateService> emailTemplateServiceMock = new();
+        UserManagementService service = new(userRepositoryMock.Object, citizenProfileRepositoryMock.Object, emailSenderMock.Object, emailTemplateServiceMock.Object, NullLogger<UserManagementService>.Instance);
+        UpdateUserRequest request = new("user-1", "citizen", null, "555-0100", UserRole.Citizen);
+
+        // Act
+        Result<UserDetailsDto> result = await service.UpdateAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be("user-1");
+        userRepositoryMock.Verify(repository => repository.UpdateAsync(It.IsAny<UpdateUserAccount>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/Beagl.Application.Tests/coverage.runsettings
+++ b/tests/Beagl.Application.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs,**/*.Tests/**/*.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/tests/Beagl.Domain.Tests/coverage.runsettings
+++ b/tests/Beagl.Domain.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs,**/*.Tests/**/*.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/tests/Beagl.Infrastructure.Tests/EmailProviders/BrevoEmailSenderTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/EmailProviders/BrevoEmailSenderTests.cs
@@ -184,4 +184,43 @@ public class BrevoEmailSenderTests
         // Assert
         configRepositoryMock.Verify(r => r.GetActiveAsync(token), Times.Once);
     }
+
+    [Fact]
+    public void Constructor_WithNullHttpClientFactory_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new BrevoEmailSender(
+            null!,
+            new Mock<IEmailProviderConfigRepository>().Object,
+            NullLogger<BrevoEmailSender>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullEmailProviderConfigRepository_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new BrevoEmailSender(
+            new Mock<IHttpClientFactory>().Object,
+            null!,
+            NullLogger<BrevoEmailSender>.Instance);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new BrevoEmailSender(
+            new Mock<IHttpClientFactory>().Object,
+            new Mock<IEmailProviderConfigRepository>().Object,
+            null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
+++ b/tests/Beagl.Infrastructure.Tests/Users/IdentityUserRepositoryTests.cs
@@ -1798,6 +1798,67 @@ public class IdentityUserRepositoryTests
         userManagerMock.Verify(manager => manager.ResetAccessFailedCountAsync(identityUser), Times.Once);
     }
 
+    [Fact]
+    public async Task FindByIdentifierAsync_WhenLockoutEndIsExpired_ShouldMapUserAsNotLockedOut()
+    {
+        // Arrange
+        ApplicationUser identityUser = new()
+        {
+            Id = "user-1",
+            UserName = "alex",
+            Email = "alex@example.com",
+            EmailConfirmed = true,
+            LockoutEnd = DateTimeOffset.UtcNow.AddDays(-1),
+        };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByNameAsync("alex"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.GetRolesAsync(identityUser))
+            .ReturnsAsync([UserRole.Employee.ToString()]);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        UserAccount? result = await repository.FindByIdentifierAsync("alex", CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.IsLockedOut.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FindByIdentifierAsync_WhenUserHasUnknownRole_ShouldMapRoleAsNone()
+    {
+        // Arrange
+        ApplicationUser identityUser = new()
+        {
+            Id = "user-1",
+            UserName = "alex",
+            Email = "alex@example.com",
+            EmailConfirmed = true,
+        };
+
+        Mock<UserManager<ApplicationUser>> userManagerMock = CreateUserManagerMock();
+        userManagerMock
+            .Setup(manager => manager.FindByNameAsync("alex"))
+            .ReturnsAsync(identityUser);
+        userManagerMock
+            .Setup(manager => manager.GetRolesAsync(identityUser))
+            .ReturnsAsync(["UnknownCustomRole"]);
+
+        IdentityUserRepository repository = new(userManagerMock.Object, CreateDbContext());
+
+        // Act
+        UserAccount? result = await repository.FindByIdentifierAsync("alex", CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Role.Should().Be(UserRole.None);
+    }
+
     private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
     {
         Mock<IUserStore<ApplicationUser>> userStoreMock = new();

--- a/tests/Beagl.Infrastructure.Tests/coverage.runsettings
+++ b/tests/Beagl.Infrastructure.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/*.g.cs,**/*.b.cs,**/*.Tests/**/*.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/tests/Beagl.WebApp.Tests/coverage.runsettings
+++ b/tests/Beagl.WebApp.Tests/coverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/Components/**/*.razor,**/*.g.cs,**/*.b.cs</ExcludeByFile>
+          <ExcludeByFile>**/Migrations/*.cs,**/*ModelSnapshot*.cs,**/Components/**/*.razor,**/*.g.cs,**/*.b.cs,**/*.Tests/**/*.cs</ExcludeByFile>
           <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute,CompilerGeneratedAttribute,GeneratedCodeAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
Introduce tests to verify that constructors in various services throw `ArgumentNullException` when provided with null dependencies. Update coverage settings to exclude test files from coverage reports.