### PR TITLE
Implement animal colors management in admin panel

### DIFF
--- a/src/Beagl.Application/Colors/Dtos/ColorDto.cs
+++ b/src/Beagl.Application/Colors/Dtos/ColorDto.cs
@@ -1,0 +1,14 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Application.Colors.Dtos;
+
+/// <summary>
+/// Represents a color returned to the UI layer.
+/// </summary>
+/// <param name="Id">The unique color identifier.</param>
+/// <param name="NameEn">The color name in English.</param>
+/// <param name="NameFr">The color name in French.</param>
+public sealed record ColorDto(
+    Guid Id,
+    string NameEn,
+    string NameFr);

--- a/src/Beagl.Application/Colors/Dtos/ColorsPageDto.cs
+++ b/src/Beagl.Application/Colors/Dtos/ColorsPageDto.cs
@@ -1,0 +1,12 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Application.Colors.Dtos;
+
+/// <summary>
+/// Represents a paginated list of colors returned to the UI layer.
+/// </summary>
+/// <param name="Items">The colors on the current page.</param>
+/// <param name="TotalCount">The total number of colors matching the query.</param>
+public sealed record ColorsPageDto(
+    IReadOnlyList<ColorDto> Items,
+    int TotalCount);

--- a/src/Beagl.Application/Colors/Dtos/SaveColorRequest.cs
+++ b/src/Beagl.Application/Colors/Dtos/SaveColorRequest.cs
@@ -1,0 +1,12 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Application.Colors.Dtos;
+
+/// <summary>
+/// Represents the data required to create or update a color.
+/// </summary>
+/// <param name="NameEn">The color name in English.</param>
+/// <param name="NameFr">The color name in French.</param>
+public sealed record SaveColorRequest(
+    string NameEn,
+    string NameFr);

--- a/src/Beagl.Application/Colors/Services/ColorService.cs
+++ b/src/Beagl.Application/Colors/Services/ColorService.cs
@@ -1,0 +1,149 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Colors.Dtos;
+using Beagl.Domain;
+using Beagl.Domain.Colors;
+using Beagl.Domain.Results;
+
+namespace Beagl.Application.Colors.Services;
+
+/// <summary>
+/// Implements management operations for animal colors.
+/// </summary>
+/// <param name="repository">The color repository.</param>
+public sealed class ColorService(IColorRepository repository) : IColorService
+{
+    private readonly IColorRepository _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+
+    /// <inheritdoc />
+    public async Task<ColorsPageDto> GetPageAsync(int page, int pageSize, CancellationToken cancellationToken)
+    {
+        GetColorsPageQuery query = new(page, pageSize);
+        ColorsPage result = await _repository.GetPageAsync(query, cancellationToken).ConfigureAwait(false);
+        return MapToPageDto(result);
+    }
+
+    /// <inheritdoc />
+    public async Task<ColorDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        Color? color = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        return color is null ? null : MapToDto(color);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<ColorDto>> CreateAsync(SaveColorRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Result validation = ValidateRequest(request);
+        if (validation.IsFailure)
+        {
+            return Result.Failure<ColorDto>(validation.Error!);
+        }
+
+        bool duplicate = await _repository.ExistsAsync(request.NameEn.Trim(), request.NameFr.Trim(), null, cancellationToken).ConfigureAwait(false);
+        if (duplicate)
+        {
+            return Result.Failure<ColorDto>(new ResultError("color.duplicate_name", "A color with the same name already exists."));
+        }
+
+        Color color = new(
+            Guid.NewGuid(),
+            request.NameEn.Trim(),
+            request.NameFr.Trim());
+
+        Color created = await _repository.CreateAsync(color, cancellationToken).ConfigureAwait(false);
+        return Result.Success(MapToDto(created));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<ColorDto>> UpdateAsync(Guid id, SaveColorRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Result validation = ValidateRequest(request);
+        if (validation.IsFailure)
+        {
+            return Result.Failure<ColorDto>(validation.Error!);
+        }
+
+        Color? existing = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return Result.Failure<ColorDto>(new ResultError("color.not_found", "The color was not found."));
+        }
+
+        bool duplicate = await _repository.ExistsAsync(request.NameEn.Trim(), request.NameFr.Trim(), id, cancellationToken).ConfigureAwait(false);
+        if (duplicate)
+        {
+            return Result.Failure<ColorDto>(new ResultError("color.duplicate_name", "A color with the same name already exists."));
+        }
+
+        Color updated = existing with
+        {
+            NameEn = request.NameEn.Trim(),
+            NameFr = request.NameFr.Trim(),
+        };
+
+        Color saved = await _repository.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
+        return Result.Success(MapToDto(saved));
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        Color? existing = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return Result.Failure(new ResultError("color.not_found", "The color was not found."));
+        }
+
+        bool inUse = await _repository.IsInUseAsync(id, cancellationToken).ConfigureAwait(false);
+        if (inUse)
+        {
+            return Result.Failure(new ResultError("color.in_use", "Cannot delete a color that is currently in use."));
+        }
+
+        await _repository.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+        return Result.Success();
+    }
+
+    private static Result ValidateRequest(SaveColorRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.NameEn))
+        {
+            return Result.Failure(new ResultError("color.name_en_required", "The English name is required."));
+        }
+
+        if (request.NameEn.Trim().Length > ValidationConstants.ColorNameMaxLength)
+        {
+            return Result.Failure(new ResultError("color.name_en_too_long", $"The English name must not exceed {ValidationConstants.ColorNameMaxLength} characters."));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.NameFr))
+        {
+            return Result.Failure(new ResultError("color.name_fr_required", "The French name is required."));
+        }
+
+        if (request.NameFr.Trim().Length > ValidationConstants.ColorNameMaxLength)
+        {
+            return Result.Failure(new ResultError("color.name_fr_too_long", $"The French name must not exceed {ValidationConstants.ColorNameMaxLength} characters."));
+        }
+
+        return Result.Success();
+    }
+
+    private static ColorDto MapToDto(Color color)
+    {
+        return new ColorDto(
+            color.Id,
+            color.NameEn,
+            color.NameFr);
+    }
+
+    private static ColorsPageDto MapToPageDto(ColorsPage page)
+    {
+        IReadOnlyList<ColorDto> items = [..page.Items.Select(MapToDto)];
+        return new ColorsPageDto(items, page.TotalCount);
+    }
+}

--- a/src/Beagl.Application/Colors/Services/IColorService.cs
+++ b/src/Beagl.Application/Colors/Services/IColorService.cs
@@ -1,0 +1,54 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Colors.Dtos;
+using Beagl.Domain.Results;
+
+namespace Beagl.Application.Colors.Services;
+
+/// <summary>
+/// Provides management operations for animal colors.
+/// </summary>
+public interface IColorService
+{
+    /// <summary>
+    /// Gets a paginated list of colors.
+    /// </summary>
+    /// <param name="page">The one-based page number.</param>
+    /// <param name="pageSize">The maximum number of items per page.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A paginated list of colors.</returns>
+    public Task<ColorsPageDto> GetPageAsync(int page, int pageSize, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a single color by its unique identifier.
+    /// </summary>
+    /// <param name="id">The color identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The color, or <see langword="null"/> if not found.</returns>
+    public Task<ColorDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a new color.
+    /// </summary>
+    /// <param name="request">The color data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The created color, or a failure result.</returns>
+    public Task<Result<ColorDto>> CreateAsync(SaveColorRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates an existing color.
+    /// </summary>
+    /// <param name="id">The identifier of the color to update.</param>
+    /// <param name="request">The updated color data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated color, or a failure result.</returns>
+    public Task<Result<ColorDto>> UpdateAsync(Guid id, SaveColorRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes a color by its unique identifier.
+    /// </summary>
+    /// <param name="id">The color identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A success result, or a failure result if the color is in use or not found.</returns>
+    public Task<Result> DeleteAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/Beagl.Domain/Colors/Color.cs
+++ b/src/Beagl.Domain/Colors/Color.cs
@@ -1,0 +1,14 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.Colors;
+
+/// <summary>
+/// Represents an animal color in the system.
+/// </summary>
+/// <param name="Id">The unique color identifier.</param>
+/// <param name="NameEn">The color name in English.</param>
+/// <param name="NameFr">The color name in French.</param>
+public sealed record Color(
+    Guid Id,
+    string NameEn,
+    string NameFr);

--- a/src/Beagl.Domain/Colors/ColorsPage.cs
+++ b/src/Beagl.Domain/Colors/ColorsPage.cs
@@ -1,0 +1,12 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.Colors;
+
+/// <summary>
+/// Represents a paginated list of colors.
+/// </summary>
+/// <param name="Items">The colors on the current page.</param>
+/// <param name="TotalCount">The total number of colors matching the query.</param>
+public sealed record ColorsPage(
+    IReadOnlyList<Color> Items,
+    int TotalCount);

--- a/src/Beagl.Domain/Colors/GetColorsPageQuery.cs
+++ b/src/Beagl.Domain/Colors/GetColorsPageQuery.cs
@@ -1,0 +1,12 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.Colors;
+
+/// <summary>
+/// Represents the parameters for a paginated color list query.
+/// </summary>
+/// <param name="Page">The one-based page number.</param>
+/// <param name="PageSize">The maximum number of items per page.</param>
+public sealed record GetColorsPageQuery(
+    int Page,
+    int PageSize);

--- a/src/Beagl.Domain/Colors/IColorRepository.cs
+++ b/src/Beagl.Domain/Colors/IColorRepository.cs
@@ -1,0 +1,66 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+namespace Beagl.Domain.Colors;
+
+/// <summary>
+/// Provides persistence operations for animal colors.
+/// </summary>
+public interface IColorRepository
+{
+    /// <summary>
+    /// Gets a paginated list of colors matching the specified query.
+    /// </summary>
+    /// <param name="query">The query parameters including pagination.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A paginated list of colors.</returns>
+    public Task<ColorsPage> GetPageAsync(GetColorsPageQuery query, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a single color by its unique identifier.
+    /// </summary>
+    /// <param name="id">The color identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The color, or <see langword="null"/> if not found.</returns>
+    public Task<Color?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Determines whether a color with the same name already exists.
+    /// </summary>
+    /// <param name="nameEn">The English name to check.</param>
+    /// <param name="nameFr">The French name to check.</param>
+    /// <param name="excludeId">An optional color identifier to exclude from the check (used on updates).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> if a duplicate exists; otherwise <see langword="false"/>.</returns>
+    public Task<bool> ExistsAsync(string nameEn, string nameFr, Guid? excludeId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Determines whether a color is currently in use by any animal record.
+    /// </summary>
+    /// <param name="id">The color identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> if the color is in use; otherwise <see langword="false"/>.</returns>
+    public Task<bool> IsInUseAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a new color.
+    /// </summary>
+    /// <param name="color">The color to create.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The created color.</returns>
+    public Task<Color> CreateAsync(Color color, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates an existing color.
+    /// </summary>
+    /// <param name="color">The color with updated values.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated color.</returns>
+    public Task<Color> UpdateAsync(Color color, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes a color by its unique identifier.
+    /// </summary>
+    /// <param name="id">The color identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public Task DeleteAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/Beagl.Domain/ValidationConstants.cs
+++ b/src/Beagl.Domain/ValidationConstants.cs
@@ -61,4 +61,9 @@ public static class ValidationConstants
     /// Maximum allowed length for a breed description.
     /// </summary>
     public const int BreedDescriptionMaxLength = 500;
+
+    /// <summary>
+    /// Maximum allowed length for a color name.
+    /// </summary>
+    public const int ColorNameMaxLength = 100;
 }

--- a/src/Beagl.Infrastructure/ApplicationDbContext.cs
+++ b/src/Beagl.Infrastructure/ApplicationDbContext.cs
@@ -3,6 +3,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Beagl.Infrastructure.Breeds;
 using Beagl.Infrastructure.Breeds.Entities;
+using Beagl.Infrastructure.Colors;
+using Beagl.Infrastructure.Colors.Entities;
 using Beagl.Infrastructure.EmailProviders.Entities;
 using Beagl.Infrastructure.Users.Entities;
 using Microsoft.AspNetCore.Identity;
@@ -24,6 +26,11 @@ public class ApplicationDbContext(
     /// Gets the breeds table.
     /// </summary>
     public DbSet<BreedEntity> Breeds => Set<BreedEntity>();
+
+    /// <summary>
+    /// Gets the colors table.
+    /// </summary>
+    public DbSet<ColorEntity> Colors => Set<ColorEntity>();
 
     /// <summary>
     /// Gets the email provider configuration table.
@@ -64,6 +71,15 @@ public class ApplicationDbContext(
             entity.Property(e => e.DescriptionFr).IsRequired().HasMaxLength(500);
             entity.Property(e => e.IsActive).IsRequired().HasDefaultValue(true);
             entity.HasData(BreedSeedData.GetAll());
+        });
+
+        builder.Entity<ColorEntity>(entity =>
+        {
+            entity.ToTable("Colors");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.NameEn).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.NameFr).IsRequired().HasMaxLength(100);
+            entity.HasData(ColorSeedData.GetAll());
         });
 
         builder.Entity<EmailProviderConfigEntity>(entity =>

--- a/src/Beagl.Infrastructure/Colors/ColorRepository.cs
+++ b/src/Beagl.Infrastructure/Colors/ColorRepository.cs
@@ -1,0 +1,128 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Domain.Colors;
+using Beagl.Infrastructure.Colors.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Beagl.Infrastructure.Colors;
+
+/// <summary>
+/// Persists animal colors through Entity Framework Core.
+/// </summary>
+/// <param name="dbContext">The application database context.</param>
+public sealed class ColorRepository(ApplicationDbContext dbContext) : IColorRepository
+{
+    private readonly ApplicationDbContext _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+
+    /// <inheritdoc />
+    public async Task<ColorsPage> GetPageAsync(GetColorsPageQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IQueryable<ColorEntity> queryable = _dbContext.Colors.AsNoTracking();
+
+        int totalCount = await queryable.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        List<ColorEntity> entities = await queryable
+            .OrderBy(e => e.NameEn)
+            .Skip((query.Page - 1) * query.PageSize)
+            .Take(query.PageSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<Color> items = entities.ConvertAll(MapToDomain);
+
+        return new ColorsPage(items, totalCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<Color?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        ColorEntity? entity = await _dbContext.Colors
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ExistsAsync(
+        string nameEn,
+        string nameFr,
+        Guid? excludeId,
+        CancellationToken cancellationToken)
+    {
+        IQueryable<ColorEntity> queryable = _dbContext.Colors
+            .AsNoTracking()
+            .Where(e => e.NameEn.Equals(nameEn, StringComparison.OrdinalIgnoreCase)
+                || e.NameFr.Equals(nameFr, StringComparison.OrdinalIgnoreCase));
+
+        if (excludeId.HasValue)
+        {
+            queryable = queryable.Where(e => e.Id != excludeId.Value);
+        }
+
+        return await queryable.AnyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsInUseAsync(Guid id, CancellationToken cancellationToken)
+    {
+        // TODO: Check animal records when the Animal entity is implemented.
+        return Task.FromResult(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Color> CreateAsync(Color color, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(color);
+
+        ColorEntity entity = new()
+        {
+            Id = color.Id,
+            NameEn = color.NameEn,
+            NameFr = color.NameFr,
+        };
+
+        _dbContext.Colors.Add(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return MapToDomain(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<Color> UpdateAsync(Color color, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(color);
+
+        ColorEntity existing = await _dbContext.Colors
+            .FirstOrDefaultAsync(e => e.Id == color.Id, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"Color with id '{color.Id}' was not found.");
+
+        existing.NameEn = color.NameEn;
+        existing.NameFr = color.NameFr;
+
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return MapToDomain(existing);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        ColorEntity existing = await _dbContext.Colors
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"Color with id '{id}' was not found.");
+
+        _dbContext.Colors.Remove(existing);
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Color MapToDomain(ColorEntity entity)
+    {
+        return new Color(entity.Id, entity.NameEn, entity.NameFr);
+    }
+}

--- a/src/Beagl.Infrastructure/Colors/ColorSeedData.cs
+++ b/src/Beagl.Infrastructure/Colors/ColorSeedData.cs
@@ -1,0 +1,51 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System.Diagnostics.CodeAnalysis;
+using Beagl.Infrastructure.Colors.Entities;
+
+namespace Beagl.Infrastructure.Colors;
+
+/// <summary>
+/// Provides deterministic seed data for common animal coat colors.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class ColorSeedData
+{
+    /// <summary>
+    /// Returns all seed color records with fixed GUIDs for EF Core change tracking.
+    /// </summary>
+    /// <returns>An array of <see cref="ColorEntity"/> seed records.</returns>
+    public static ColorEntity[] GetAll() =>
+    [
+        new ColorEntity { Id = new Guid("10000001-0000-0000-0000-000000000000"), NameEn = "Black", NameFr = "Noir" },
+        new ColorEntity { Id = new Guid("10000002-0000-0000-0000-000000000000"), NameEn = "White", NameFr = "Blanc" },
+        new ColorEntity { Id = new Guid("10000003-0000-0000-0000-000000000000"), NameEn = "Brown", NameFr = "Brun" },
+        new ColorEntity { Id = new Guid("10000004-0000-0000-0000-000000000000"), NameEn = "Gray", NameFr = "Gris" },
+        new ColorEntity { Id = new Guid("10000005-0000-0000-0000-000000000000"), NameEn = "Orange", NameFr = "Orange" },
+        new ColorEntity { Id = new Guid("10000006-0000-0000-0000-000000000000"), NameEn = "Red", NameFr = "Roux" },
+        new ColorEntity { Id = new Guid("10000007-0000-0000-0000-000000000000"), NameEn = "Cream", NameFr = "Crème" },
+        new ColorEntity { Id = new Guid("10000008-0000-0000-0000-000000000000"), NameEn = "Golden", NameFr = "Doré" },
+        new ColorEntity { Id = new Guid("10000009-0000-0000-0000-000000000000"), NameEn = "Silver", NameFr = "Argenté" },
+        new ColorEntity { Id = new Guid("10000010-0000-0000-0000-000000000000"), NameEn = "Blue", NameFr = "Bleu" },
+        new ColorEntity { Id = new Guid("10000011-0000-0000-0000-000000000000"), NameEn = "Chocolate", NameFr = "Chocolat" },
+        new ColorEntity { Id = new Guid("10000012-0000-0000-0000-000000000000"), NameEn = "Fawn", NameFr = "Fauve" },
+        new ColorEntity { Id = new Guid("10000013-0000-0000-0000-000000000000"), NameEn = "Tan", NameFr = "Beige" },
+        new ColorEntity { Id = new Guid("10000014-0000-0000-0000-000000000000"), NameEn = "Merle", NameFr = "Merle" },
+        new ColorEntity { Id = new Guid("10000015-0000-0000-0000-000000000000"), NameEn = "Brindle", NameFr = "Bringé" },
+        new ColorEntity { Id = new Guid("10000016-0000-0000-0000-000000000000"), NameEn = "Sable", NameFr = "Sable" },
+        new ColorEntity { Id = new Guid("10000017-0000-0000-0000-000000000000"), NameEn = "Spotted", NameFr = "Tacheté" },
+        new ColorEntity { Id = new Guid("10000018-0000-0000-0000-000000000000"), NameEn = "Tricolor", NameFr = "Tricolore" },
+        new ColorEntity { Id = new Guid("10000019-0000-0000-0000-000000000000"), NameEn = "Bicolor", NameFr = "Bicolore" },
+        new ColorEntity { Id = new Guid("10000020-0000-0000-0000-000000000000"), NameEn = "Tabby", NameFr = "Tigré" },
+        new ColorEntity { Id = new Guid("10000021-0000-0000-0000-000000000000"), NameEn = "Calico", NameFr = "Calico" },
+        new ColorEntity { Id = new Guid("10000022-0000-0000-0000-000000000000"), NameEn = "Tortoiseshell", NameFr = "Écaille de tortue" },
+        new ColorEntity { Id = new Guid("10000023-0000-0000-0000-000000000000"), NameEn = "Seal Point", NameFr = "Seal Point" },
+        new ColorEntity { Id = new Guid("10000024-0000-0000-0000-000000000000"), NameEn = "Lilac", NameFr = "Lilas" },
+        new ColorEntity { Id = new Guid("10000025-0000-0000-0000-000000000000"), NameEn = "Cinnamon", NameFr = "Cannelle" },
+        new ColorEntity { Id = new Guid("10000026-0000-0000-0000-000000000000"), NameEn = "Apricot", NameFr = "Abricot" },
+        new ColorEntity { Id = new Guid("10000027-0000-0000-0000-000000000000"), NameEn = "Champagne", NameFr = "Champagne" },
+        new ColorEntity { Id = new Guid("10000028-0000-0000-0000-000000000000"), NameEn = "Platinum", NameFr = "Platine" },
+        new ColorEntity { Id = new Guid("10000029-0000-0000-0000-000000000000"), NameEn = "Smoke", NameFr = "Fumé" },
+        new ColorEntity { Id = new Guid("10000030-0000-0000-0000-000000000000"), NameEn = "Tuxedo", NameFr = "Tuxedo" },
+    ];
+}

--- a/src/Beagl.Infrastructure/Colors/Entities/ColorEntity.cs
+++ b/src/Beagl.Infrastructure/Colors/Entities/ColorEntity.cs
@@ -1,0 +1,27 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Beagl.Infrastructure.Colors.Entities;
+
+/// <summary>
+/// Represents the persisted animal color row.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class ColorEntity
+{
+    /// <summary>
+    /// Gets or sets the unique color identifier.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the color name in English.
+    /// </summary>
+    public string NameEn { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the color name in French.
+    /// </summary>
+    public string NameFr { get; set; } = string.Empty;
+}

--- a/src/Beagl.Infrastructure/Migrations/20260410191117_AddColors.Designer.cs
+++ b/src/Beagl.Infrastructure/Migrations/20260410191117_AddColors.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Beagl.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Beagl.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410191117_AddColors")]
+    partial class AddColors
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Beagl.Infrastructure/Migrations/20260410191117_AddColors.cs
+++ b/src/Beagl.Infrastructure/Migrations/20260410191117_AddColors.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Beagl.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddColors : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Colors",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    NameEn = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    NameFr = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Colors", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Colors",
+                columns: new[] { "Id", "NameEn", "NameFr" },
+                values: new object[,]
+                {
+                    { new Guid("10000001-0000-0000-0000-000000000000"), "Black", "Noir" },
+                    { new Guid("10000002-0000-0000-0000-000000000000"), "White", "Blanc" },
+                    { new Guid("10000003-0000-0000-0000-000000000000"), "Brown", "Brun" },
+                    { new Guid("10000004-0000-0000-0000-000000000000"), "Gray", "Gris" },
+                    { new Guid("10000005-0000-0000-0000-000000000000"), "Orange", "Orange" },
+                    { new Guid("10000006-0000-0000-0000-000000000000"), "Red", "Roux" },
+                    { new Guid("10000007-0000-0000-0000-000000000000"), "Cream", "Crème" },
+                    { new Guid("10000008-0000-0000-0000-000000000000"), "Golden", "Doré" },
+                    { new Guid("10000009-0000-0000-0000-000000000000"), "Silver", "Argenté" },
+                    { new Guid("10000010-0000-0000-0000-000000000000"), "Blue", "Bleu" },
+                    { new Guid("10000011-0000-0000-0000-000000000000"), "Chocolate", "Chocolat" },
+                    { new Guid("10000012-0000-0000-0000-000000000000"), "Fawn", "Fauve" },
+                    { new Guid("10000013-0000-0000-0000-000000000000"), "Tan", "Beige" },
+                    { new Guid("10000014-0000-0000-0000-000000000000"), "Merle", "Merle" },
+                    { new Guid("10000015-0000-0000-0000-000000000000"), "Brindle", "Bringé" },
+                    { new Guid("10000016-0000-0000-0000-000000000000"), "Sable", "Sable" },
+                    { new Guid("10000017-0000-0000-0000-000000000000"), "Spotted", "Tacheté" },
+                    { new Guid("10000018-0000-0000-0000-000000000000"), "Tricolor", "Tricolore" },
+                    { new Guid("10000019-0000-0000-0000-000000000000"), "Bicolor", "Bicolore" },
+                    { new Guid("10000020-0000-0000-0000-000000000000"), "Tabby", "Tigré" },
+                    { new Guid("10000021-0000-0000-0000-000000000000"), "Calico", "Calico" },
+                    { new Guid("10000022-0000-0000-0000-000000000000"), "Tortoiseshell", "Écaille de tortue" },
+                    { new Guid("10000023-0000-0000-0000-000000000000"), "Seal Point", "Seal Point" },
+                    { new Guid("10000024-0000-0000-0000-000000000000"), "Lilac", "Lilas" },
+                    { new Guid("10000025-0000-0000-0000-000000000000"), "Cinnamon", "Cannelle" },
+                    { new Guid("10000026-0000-0000-0000-000000000000"), "Apricot", "Abricot" },
+                    { new Guid("10000027-0000-0000-0000-000000000000"), "Champagne", "Champagne" },
+                    { new Guid("10000028-0000-0000-0000-000000000000"), "Platinum", "Platine" },
+                    { new Guid("10000029-0000-0000-0000-000000000000"), "Smoke", "Fumé" },
+                    { new Guid("10000030-0000-0000-0000-000000000000"), "Tuxedo", "Tuxedo" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Colors");
+        }
+    }
+}

--- a/src/Beagl.Infrastructure/Migrations/MigrationCoverageExclusions.g.cs
+++ b/src/Beagl.Infrastructure/Migrations/MigrationCoverageExclusions.g.cs
@@ -60,3 +60,8 @@ partial class AddBreeds
 partial class SeedBreeds
 {
 }
+
+[ExcludeFromCodeCoverage]
+partial class AddColors
+{
+}

--- a/src/Beagl.WebApp/Components/Admin/BreedsTab.razor
+++ b/src/Beagl.WebApp/Components/Admin/BreedsTab.razor
@@ -64,8 +64,8 @@ else
                 <table class="table align-middle breeds-table mb-0">
                     <thead>
                         <tr>
-                            <th scope="col">@L["Breeds.Table.NameEn"]</th>
-                            <th scope="col">@L["Breeds.Table.NameFr"]</th>
+                            <th scope="col">@L["Breeds.Table.Name"]</th>
+                            <th scope="col">@L["Breeds.Table.Description"]</th>
                             <th scope="col">@L["Breeds.Table.AnimalType"]</th>
                             <th scope="col">@L["Breeds.Table.Status"]</th>
                             <th scope="col" class="text-end">@L["Breeds.Table.Actions"]</th>
@@ -75,8 +75,8 @@ else
                         @foreach (BreedDto breed in _breeds)
                         {
                             <tr>
-                                <td>@breed.NameEn</td>
-                                <td>@breed.NameFr</td>
+                                <td>@LocalizeName(breed.NameEn, breed.NameFr)</td>
+                                <td>@LocalizeName(breed.DescriptionEn, breed.DescriptionFr)</td>
                                 <td>@LocalizeAnimalType(breed.AnimalType)</td>
                                 <td>
                                     @if (breed.IsActive)

--- a/src/Beagl.WebApp/Components/Admin/BreedsTab.razor.cs
+++ b/src/Beagl.WebApp/Components/Admin/BreedsTab.razor.cs
@@ -4,6 +4,7 @@
 #pragma warning disable CA1031 // Do not catch general exception types
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Beagl.Application.Breeds.Dtos;
 using Beagl.Application.Breeds.Services;
 using Beagl.Domain.Breeds;
@@ -269,6 +270,11 @@ public sealed partial class BreedsTab : IDisposable
         }
 
         _isSaving = false;
+    }
+
+    private static string LocalizeName(string en, string fr)
+    {
+        return CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "fr" ? fr : en;
     }
 
     private string LocalizeAnimalType(AnimalType animalType)

--- a/src/Beagl.WebApp/Components/Admin/ColorsTab.razor
+++ b/src/Beagl.WebApp/Components/Admin/ColorsTab.razor
@@ -1,0 +1,170 @@
+@if (!string.IsNullOrWhiteSpace(_statusMessage))
+{
+    <div class="alert alert-success mb-4" role="status" aria-live="polite">@_statusMessage</div>
+}
+
+@if (!string.IsNullOrWhiteSpace(_errorMessage))
+{
+    <div class="alert alert-danger mb-4" role="alert" aria-live="assertive">@_errorMessage</div>
+}
+
+@if (_isLoading)
+{
+    <div class="colors-loading py-5" role="status" aria-live="polite">
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">@L["Colors.Loading"]</span>
+        </div>
+    </div>
+}
+else
+{
+    <div class="colors-surface">
+        <div class="breeds-surface__header">
+            <div>
+                <h2 class="h4 mb-1">@L["Colors.Directory.Title"]</h2>
+                <p class="text-secondary mb-0">@L["Colors.Directory.Description"]</p>
+            </div>
+            <div class="d-flex flex-wrap align-items-center gap-3">
+                <button type="button" class="btn btn-primary" @onclick="OpenCreateModal">
+                    <i class="bi bi-plus-circle me-2" aria-hidden="true"></i>
+                    @L["Colors.Action.Create"]
+                </button>
+            </div>
+        </div>
+
+        @if (_colors.Count == 0)
+        {
+            <div class="colors-empty-state py-5" data-testid="colors-empty-state">
+                <div class="colors-empty-state__icon"><i class="bi bi-palette"></i></div>
+                <h3 class="h5">@L["Colors.Empty.Title"]</h3>
+                <p class="text-secondary mb-0">@L["Colors.Empty.Description"]</p>
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table align-middle colors-table mb-0">
+                    <thead>
+                        <tr>
+                            <th scope="col">@L["Colors.Table.Name"]</th>
+                            <th scope="col" class="text-end">@L["Colors.Table.Actions"]</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (ColorDto color in _colors)
+                        {
+                            <tr>
+                                <td>@LocalizeName(color.NameEn, color.NameFr)</td>
+                                <td>
+                                    <div class="d-flex justify-content-end gap-2">
+                                        <button
+                                            type="button"
+                                            class="breeds-icon-action"
+                                            @onclick="() => OpenEditModal(color)"
+                                            data-testid="edit-@color.Id"
+                                            aria-label='@L["Colors.Action.Edit"]'
+                                            title='@L["Colors.Action.Edit"]'
+                                            disabled="@_isSaving">
+                                            <i class="bi bi-pencil-square" aria-hidden="true"></i>
+                                        </button>
+                                        <button
+                                            type="button"
+                                            class="breeds-icon-action colors-icon-action--danger"
+                                            @onclick="() => ConfirmDelete(color.Id)"
+                                            data-testid="delete-@color.Id"
+                                            aria-label='@L["Colors.Action.Delete"]'
+                                            title='@L["Colors.Action.Delete"]'
+                                            disabled="@_isSaving">
+                                            <i class="bi bi-trash" aria-hidden="true"></i>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="colors-pagination">
+                <p class="text-secondary mb-0">@L["Colors.Pagination.Summary", PageStartIndex, PageEndIndex, _totalCount]</p>
+                <div class="btn-group" role="group" aria-label="@L["Colors.Pagination.Aria"]">
+                    <button type="button" class="btn btn-outline-secondary" @onclick="GoToPreviousPageAsync" disabled="@(!CanGoPreviousPage)">@L["Colors.Pagination.Previous"]</button>
+                    <span class="btn btn-outline-secondary disabled">@L["Colors.Pagination.Page", _currentPage, TotalPages]</span>
+                    <button type="button" class="btn btn-outline-secondary" @onclick="GoToNextPageAsync" disabled="@(!CanGoNextPage)">@L["Colors.Pagination.Next"]</button>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@if (_showModal)
+{
+    <div class="colors-modal-backdrop" @onclick="CloseModal">
+        <div class="colors-modal"
+             role="dialog"
+             aria-modal="true"
+             aria-labelledby="colors-modal-title"
+             @onclick:stopPropagation="true">
+            <div class="breeds-modal__header">
+                <div>
+                    <h2 id="colors-modal-title" class="h4 mb-1">@(_editingColorId is null ? L["Colors.Modal.Title.Create"] : L["Colors.Modal.Title.Edit"])</h2>
+                    <p class="text-secondary mb-0">@(_editingColorId is null ? L["Colors.Modal.Description.Create"] : L["Colors.Modal.Description.Edit"])</p>
+                </div>
+            </div>
+
+            @if (_formErrors.Count > 0)
+            {
+                <div class="alert alert-danger" role="alert">
+                    <ul class="mb-0 ps-3">
+                        @foreach (string error in _formErrors)
+                        {
+                            <li>@error</li>
+                        }
+                    </ul>
+                </div>
+            }
+
+            <EditForm Model="_form" OnValidSubmit="SaveColorAsync">
+                <div class="colors-form-grid">
+                    <div>
+                        <label class="form-label" for="colorNameEn">@L["Colors.Form.NameEn"]</label>
+                        <InputText id="colorNameEn" class="form-control" @bind-Value="_form.NameEn" />
+                    </div>
+                    <div>
+                        <label class="form-label" for="colorNameFr">@L["Colors.Form.NameFr"]</label>
+                        <InputText id="colorNameFr" class="form-control" @bind-Value="_form.NameFr" />
+                    </div>
+                </div>
+
+                <div class="d-flex justify-content-end gap-3 mt-4">
+                    <button type="button" class="btn btn-outline-secondary" @onclick="CloseModal">@L["Colors.Action.Cancel"]</button>
+                    <button type="submit" class="btn btn-primary" disabled="@_isSaving">@L["Colors.Action.Save"]</button>
+                </div>
+            </EditForm>
+        </div>
+    </div>
+}
+
+@if (_showDeleteConfirm)
+{
+    <div class="colors-modal-backdrop" @onclick="CancelDelete">
+        <div class="colors-modal"
+             role="dialog"
+             aria-modal="true"
+             aria-labelledby="colors-delete-modal-title"
+             @onclick:stopPropagation="true">
+            <div class="breeds-modal__header">
+                <div>
+                    <h2 id="colors-delete-modal-title" class="h4 mb-1">@L["Colors.Delete.Title"]</h2>
+                </div>
+            </div>
+
+            <p class="text-secondary mb-4">@L["Colors.Delete.Confirmation"]</p>
+
+            <div class="d-flex justify-content-end gap-3">
+                <button type="button" class="btn btn-outline-secondary" @onclick="CancelDelete" disabled="@_isSaving">@L["Colors.Action.Cancel"]</button>
+                <button type="button" class="btn btn-danger" @onclick="DeleteColorAsync" disabled="@_isSaving">@L["Colors.Delete.Confirm"]</button>
+            </div>
+        </div>
+    </div>
+}

--- a/src/Beagl.WebApp/Components/Admin/ColorsTab.razor.cs
+++ b/src/Beagl.WebApp/Components/Admin/ColorsTab.razor.cs
@@ -1,0 +1,281 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+// Blazor event handlers catch all exceptions to prevent SignalR circuit failures.
+#pragma warning disable CA1031 // Do not catch general exception types
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Beagl.Application.Colors.Dtos;
+using Beagl.Application.Colors.Services;
+using Beagl.Domain.Results;
+using Beagl.WebApp.Extensions;
+using Beagl.WebApp.Resources;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace Beagl.WebApp.Components.Admin;
+
+/// <summary>
+/// Code-behind for the animal colors management tab component.
+/// </summary>
+public sealed partial class ColorsTab : IDisposable
+{
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<ColorDto> _colors = [];
+    private readonly List<string> _formErrors = [];
+    private readonly ColorFormModel _form = new();
+    private const int _pageSize = 10;
+
+    private bool _isLoading = true;
+    private bool _isSaving;
+    private bool _showModal;
+    private bool _showDeleteConfirm;
+    private int _currentPage = 1;
+    private int _totalCount;
+    private Guid? _editingColorId;
+    private Guid? _deletingColorId;
+    private string? _statusMessage;
+    private string? _errorMessage;
+
+    [Inject]
+    private IColorService ColorService { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<ColorsResource> L { get; set; } = default!;
+
+    [Inject]
+    private ILogger<ColorsTab> Logger { get; set; } = default!;
+
+    private int TotalPages => Math.Max(1, (int)Math.Ceiling((double)_totalCount / _pageSize));
+
+    private int PageStartIndex => _totalCount == 0 ? 0 : ((_currentPage - 1) * _pageSize) + 1;
+
+    private int PageEndIndex => _totalCount == 0 ? 0 : Math.Min(_currentPage * _pageSize, _totalCount);
+
+    private bool CanGoPreviousPage => _currentPage > 1;
+
+    private bool CanGoNextPage => _currentPage < TotalPages;
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadColorsAsync().ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+
+    private async Task LoadColorsAsync()
+    {
+        _isLoading = true;
+        _errorMessage = null;
+
+        try
+        {
+            ColorsPageDto page = await ColorService
+                .GetPageAsync(_currentPage, _pageSize, _cts.Token)
+                .ConfigureAwait(false);
+
+            _colors.Clear();
+            _colors.AddRange(page.Items);
+            _totalCount = page.TotalCount;
+        }
+        catch (Exception exception)
+        {
+            LogLoadColorsFailed(Logger, exception);
+            _errorMessage = L["Colors.Error.LoadFailed"];
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task GoToPreviousPageAsync()
+    {
+        if (!CanGoPreviousPage)
+        {
+            return;
+        }
+
+        _currentPage--;
+        await LoadColorsAsync().ConfigureAwait(false);
+    }
+
+    private async Task GoToNextPageAsync()
+    {
+        if (!CanGoNextPage)
+        {
+            return;
+        }
+
+        _currentPage++;
+        await LoadColorsAsync().ConfigureAwait(false);
+    }
+
+    private void OpenCreateModal()
+    {
+        _editingColorId = null;
+        _form.Reset();
+        _formErrors.Clear();
+        _showModal = true;
+        _statusMessage = null;
+        _errorMessage = null;
+    }
+
+    private void OpenEditModal(ColorDto color)
+    {
+        _editingColorId = color.Id;
+        _form.NameEn = color.NameEn;
+        _form.NameFr = color.NameFr;
+        _formErrors.Clear();
+        _showModal = true;
+        _statusMessage = null;
+        _errorMessage = null;
+    }
+
+    private void CloseModal()
+    {
+        _showModal = false;
+        _formErrors.Clear();
+    }
+
+    private async Task SaveColorAsync()
+    {
+        _isSaving = true;
+        _formErrors.Clear();
+
+        try
+        {
+            SaveColorRequest request = new(_form.NameEn, _form.NameFr);
+
+            if (_editingColorId is null)
+            {
+                Result<ColorDto> result = await ColorService.CreateAsync(request, _cts.Token).ConfigureAwait(false);
+
+                if (result.IsFailure)
+                {
+                    _formErrors.Add(L.LocalizeError(result.Error!));
+                    _isSaving = false;
+                    return;
+                }
+
+                _showModal = false;
+                _statusMessage = L["Colors.Success.Created"];
+            }
+            else
+            {
+                Result<ColorDto> result = await ColorService
+                    .UpdateAsync(_editingColorId.Value, request, _cts.Token)
+                    .ConfigureAwait(false);
+
+                if (result.IsFailure)
+                {
+                    _formErrors.Add(L.LocalizeError(result.Error!));
+                    _isSaving = false;
+                    return;
+                }
+
+                _showModal = false;
+                _statusMessage = L["Colors.Success.Updated"];
+            }
+
+            await LoadColorsAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            LogSaveColorFailed(Logger, exception);
+            _formErrors.Add(L["Colors.Error.UnexpectedError"]);
+        }
+
+        _isSaving = false;
+    }
+
+    private void ConfirmDelete(Guid colorId)
+    {
+        _deletingColorId = colorId;
+        _showDeleteConfirm = true;
+        _statusMessage = null;
+        _errorMessage = null;
+    }
+
+    private void CancelDelete()
+    {
+        _showDeleteConfirm = false;
+        _deletingColorId = null;
+    }
+
+    private async Task DeleteColorAsync()
+    {
+        if (_deletingColorId is null)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        _errorMessage = null;
+        _statusMessage = null;
+
+        try
+        {
+            Result result = await ColorService.DeleteAsync(_deletingColorId.Value, _cts.Token).ConfigureAwait(false);
+
+            if (result.IsFailure)
+            {
+                _showDeleteConfirm = false;
+                _deletingColorId = null;
+                _errorMessage = L.LocalizeError(result.Error!);
+                _isSaving = false;
+                return;
+            }
+
+            _showDeleteConfirm = false;
+            _deletingColorId = null;
+            _statusMessage = L["Colors.Success.Deleted"];
+            await LoadColorsAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            LogDeleteColorFailed(Logger, exception);
+            _showDeleteConfirm = false;
+            _deletingColorId = null;
+            _errorMessage = L["Colors.Error.UnexpectedError"];
+        }
+
+        _isSaving = false;
+    }
+
+    private static string LocalizeName(string en, string fr)
+    {
+        return CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "fr" ? fr : en;
+    }
+
+    [ExcludeFromCodeCoverage]
+    [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Failed to load colors")]
+    private static partial void LogLoadColorsFailed(ILogger logger, Exception exception);
+
+    [ExcludeFromCodeCoverage]
+    [LoggerMessage(EventId = 2, Level = LogLevel.Error, Message = "Failed to save color")]
+    private static partial void LogSaveColorFailed(ILogger logger, Exception exception);
+
+    [ExcludeFromCodeCoverage]
+    [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "Failed to delete color")]
+    private static partial void LogDeleteColorFailed(ILogger logger, Exception exception);
+
+    private sealed class ColorFormModel
+    {
+        public string NameEn { get; set; } = string.Empty;
+
+        public string NameFr { get; set; } = string.Empty;
+
+        public void Reset()
+        {
+            NameEn = string.Empty;
+            NameFr = string.Empty;
+        }
+    }
+}

--- a/src/Beagl.WebApp/Components/Pages/Admin.razor
+++ b/src/Beagl.WebApp/Components/Pages/Admin.razor
@@ -38,22 +38,48 @@
                         @L["Admin.Tab.Breeds"]
                     </button>
                 </li>
+                <li class="nav-item" role="presentation">
+                    <button type="button"
+                            class="nav-link @(_activeTab == _tabColors ? "active" : string.Empty)"
+                            id="tab-colors"
+                            role="tab"
+                            aria-controls="tab-panel-colors"
+                            aria-selected="@(_activeTab == _tabColors)"
+                            @onclick='() => SetTab(_tabColors)'>
+                        @L["Admin.Tab.Colors"]
+                    </button>
+                </li>
             </ul>
         </div>
 
         <div class="tab-content">
-            <div id="tab-panel-email"
-                 class="tab-pane @(_activeTab == _tabEmail ? "show active" : string.Empty)"
-                 role="tabpanel"
-                 aria-labelledby="tab-email">
-                <EmailConfigTab />
-            </div>
-            <div id="tab-panel-breeds"
-                 class="tab-pane @(_activeTab == _tabBreeds ? "show active" : string.Empty)"
-                 role="tabpanel"
-                 aria-labelledby="tab-breeds">
-                <BreedsTab />
-            </div>
+            @if (_activeTab == _tabEmail)
+            {
+                <div id="tab-panel-email"
+                     class="tab-pane show active"
+                     role="tabpanel"
+                     aria-labelledby="tab-email">
+                    <EmailConfigTab />
+                </div>
+            }
+            @if (_activeTab == _tabBreeds)
+            {
+                <div id="tab-panel-breeds"
+                     class="tab-pane show active"
+                     role="tabpanel"
+                     aria-labelledby="tab-breeds">
+                    <BreedsTab />
+                </div>
+            }
+            @if (_activeTab == _tabColors)
+            {
+                <div id="tab-panel-colors"
+                     class="tab-pane show active"
+                     role="tabpanel"
+                     aria-labelledby="tab-colors">
+                    <ColorsTab />
+                </div>
+            }
         </div>
     </div>
 </section>

--- a/src/Beagl.WebApp/Components/Pages/Admin.razor.cs
+++ b/src/Beagl.WebApp/Components/Pages/Admin.razor.cs
@@ -13,6 +13,7 @@ public sealed partial class Admin
 {
     private const string _tabEmail = "email";
     private const string _tabBreeds = "breeds";
+    private const string _tabColors = "colors";
 
     private string _activeTab = _tabEmail;
 

--- a/src/Beagl.WebApp/Components/_Imports.razor
+++ b/src/Beagl.WebApp/Components/_Imports.razor
@@ -2,6 +2,7 @@
 @using System.Diagnostics.CodeAnalysis
 @using Beagl.Application.Breeds.Dtos
 @using Beagl.Application.Breeds.Services
+@using Beagl.Application.Colors.Dtos
 @using Beagl.Application.CitizenProfiles.Dtos
 @using Beagl.Application.CitizenProfiles.Services
 @using Beagl.Application.Users.Dtos

--- a/src/Beagl.WebApp/Program.cs
+++ b/src/Beagl.WebApp/Program.cs
@@ -3,7 +3,9 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Beagl.Infrastructure;
+using Beagl.Application.Colors.Services;
 using Beagl.Infrastructure.Breeds;
+using Beagl.Infrastructure.Colors;
 using Beagl.Infrastructure.EmailProviders;
 using Beagl.Infrastructure.Users;
 using Beagl.Infrastructure.Users.Entities;
@@ -13,6 +15,7 @@ using Beagl.Application.EmailProviders.Services;
 using Beagl.Application.Setup.Services;
 using Beagl.Application.Users.Services;
 using Beagl.Domain.Breeds;
+using Beagl.Domain.Colors;
 using Beagl.Domain.EmailProviders;
 using Beagl.Domain.Users;
 using Beagl.WebApp.Authentication;
@@ -102,6 +105,8 @@ builder.Services.AddScoped<ICitizenProfileRepository, CitizenProfileRepository>(
 builder.Services.AddScoped<ICitizenProfileService, CitizenProfileService>();
 builder.Services.AddScoped<IBreedRepository, BreedRepository>();
 builder.Services.AddScoped<IBreedService, BreedService>();
+builder.Services.AddScoped<IColorRepository, ColorRepository>();
+builder.Services.AddScoped<IColorService, ColorService>();
 
 builder.Services.AddHsts(options =>
 {

--- a/src/Beagl.WebApp/Resources/Resources.AdminResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.AdminResource.fr.resx
@@ -10,4 +10,5 @@
   <data name="Admin.Copy" xml:space="preserve"><value>Gérez les paramètres et la configuration à l'échelle du système pour l'application.</value></data>
   <data name="Admin.Tab.Email" xml:space="preserve"><value>Courriel</value></data>
   <data name="Admin.Tab.Breeds" xml:space="preserve"><value>Races</value></data>
+  <data name="Admin.Tab.Colors" xml:space="preserve"><value>Couleurs</value></data>
 </root>

--- a/src/Beagl.WebApp/Resources/Resources.AdminResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.AdminResource.resx
@@ -10,4 +10,5 @@
   <data name="Admin.Copy" xml:space="preserve"><value>Manage system-wide settings and configuration for the application.</value></data>
   <data name="Admin.Tab.Email" xml:space="preserve"><value>Email</value></data>
   <data name="Admin.Tab.Breeds" xml:space="preserve"><value>Breeds</value></data>
+  <data name="Admin.Tab.Colors" xml:space="preserve"><value>Colors</value></data>
 </root>

--- a/src/Beagl.WebApp/Resources/Resources.BreedsResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.BreedsResource.fr.resx
@@ -6,6 +6,8 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value></resheader>
 
   <!-- Table headers -->
+  <data name="Breeds.Table.Name" xml:space="preserve"><value>Nom</value></data>
+  <data name="Breeds.Table.Description" xml:space="preserve"><value>Description</value></data>
   <data name="Breeds.Table.NameEn" xml:space="preserve"><value>Nom (AN)</value></data>
   <data name="Breeds.Table.NameFr" xml:space="preserve"><value>Nom (FR)</value></data>
   <data name="Breeds.Table.AnimalType" xml:space="preserve"><value>Type d'animal</value></data>

--- a/src/Beagl.WebApp/Resources/Resources.BreedsResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.BreedsResource.resx
@@ -6,6 +6,8 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value></resheader>
 
   <!-- Table headers -->
+  <data name="Breeds.Table.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Breeds.Table.Description" xml:space="preserve"><value>Description</value></data>
   <data name="Breeds.Table.NameEn" xml:space="preserve"><value>Name (EN)</value></data>
   <data name="Breeds.Table.NameFr" xml:space="preserve"><value>Name (FR)</value></data>
   <data name="Breeds.Table.AnimalType" xml:space="preserve"><value>Animal Type</value></data>

--- a/src/Beagl.WebApp/Resources/Resources.ColorsResource.fr.resx
+++ b/src/Beagl.WebApp/Resources/Resources.ColorsResource.fr.resx
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value></resheader>
+
+  <!-- Table headers -->
+  <data name="Colors.Table.Name" xml:space="preserve"><value>Nom</value></data>
+  <data name="Colors.Table.NameEn" xml:space="preserve"><value>Nom (AN)</value></data>
+  <data name="Colors.Table.NameFr" xml:space="preserve"><value>Nom (FR)</value></data>
+  <data name="Colors.Table.Actions" xml:space="preserve"><value>Actions</value></data>
+
+  <!-- Actions -->
+  <data name="Colors.Action.Create" xml:space="preserve"><value>Ajouter une couleur</value></data>
+  <data name="Colors.Action.Edit" xml:space="preserve"><value>Modifier la couleur</value></data>
+  <data name="Colors.Action.Delete" xml:space="preserve"><value>Supprimer la couleur</value></data>
+  <data name="Colors.Action.Save" xml:space="preserve"><value>Enregistrer</value></data>
+  <data name="Colors.Action.Cancel" xml:space="preserve"><value>Annuler</value></data>
+
+  <!-- Modal -->
+  <data name="Colors.Modal.Title.Create" xml:space="preserve"><value>Ajouter une couleur</value></data>
+  <data name="Colors.Modal.Title.Edit" xml:space="preserve"><value>Modifier la couleur</value></data>
+  <data name="Colors.Modal.Description.Create" xml:space="preserve"><value>Remplissez les informations pour ajouter une nouvelle couleur.</value></data>
+  <data name="Colors.Modal.Description.Edit" xml:space="preserve"><value>Mettez à jour les informations de la couleur ci-dessous.</value></data>
+
+  <!-- Delete confirmation -->
+  <data name="Colors.Delete.Title" xml:space="preserve"><value>Supprimer la couleur</value></data>
+  <data name="Colors.Delete.Confirmation" xml:space="preserve"><value>Êtes-vous sûr de vouloir supprimer cette couleur ? Cette action est irréversible.</value></data>
+  <data name="Colors.Delete.Confirm" xml:space="preserve"><value>Supprimer</value></data>
+
+  <!-- Form -->
+  <data name="Colors.Form.NameEn" xml:space="preserve"><value>Nom (anglais)</value></data>
+  <data name="Colors.Form.NameFr" xml:space="preserve"><value>Nom (français)</value></data>
+
+  <!-- Success messages -->
+  <data name="Colors.Success.Created" xml:space="preserve"><value>Couleur créée avec succès.</value></data>
+  <data name="Colors.Success.Updated" xml:space="preserve"><value>Couleur mise à jour avec succès.</value></data>
+  <data name="Colors.Success.Deleted" xml:space="preserve"><value>Couleur supprimée avec succès.</value></data>
+
+  <!-- Loading -->
+  <data name="Colors.Loading" xml:space="preserve"><value>Chargement des couleurs…</value></data>
+
+  <!-- Empty state -->
+  <data name="Colors.Empty.Title" xml:space="preserve"><value>Aucune couleur trouvée</value></data>
+  <data name="Colors.Empty.Description" xml:space="preserve"><value>Aucune couleur n'a encore été ajoutée.</value></data>
+
+  <!-- Pagination -->
+  <data name="Colors.Pagination.Summary" xml:space="preserve"><value>Affichage de {0}–{1} sur {2} couleurs</value></data>
+  <data name="Colors.Pagination.Aria" xml:space="preserve"><value>Pagination des couleurs</value></data>
+  <data name="Colors.Pagination.Previous" xml:space="preserve"><value>Précédent</value></data>
+  <data name="Colors.Pagination.Next" xml:space="preserve"><value>Suivant</value></data>
+  <data name="Colors.Pagination.Page" xml:space="preserve"><value>Page {0} sur {1}</value></data>
+
+  <!-- Surface header -->
+  <data name="Colors.Directory.Title" xml:space="preserve"><value>Répertoire des couleurs</value></data>
+  <data name="Colors.Directory.Description" xml:space="preserve"><value>Gérez les couleurs d'animaux disponibles pour la sélection dans le système.</value></data>
+
+  <!-- Error codes from ColorService -->
+  <data name="color.name_en_required" xml:space="preserve"><value>Le nom en anglais est requis.</value></data>
+  <data name="color.name_en_too_long" xml:space="preserve"><value>Le nom en anglais ne doit pas dépasser 100 caractères.</value></data>
+  <data name="color.name_fr_required" xml:space="preserve"><value>Le nom en français est requis.</value></data>
+  <data name="color.name_fr_too_long" xml:space="preserve"><value>Le nom en français ne doit pas dépasser 100 caractères.</value></data>
+  <data name="color.duplicate_name" xml:space="preserve"><value>Une couleur avec ce nom existe déjà.</value></data>
+  <data name="color.not_found" xml:space="preserve"><value>La couleur est introuvable.</value></data>
+  <data name="color.in_use" xml:space="preserve"><value>Impossible de supprimer une couleur actuellement utilisée.</value></data>
+
+  <!-- General errors -->
+  <data name="Colors.Error.LoadFailed" xml:space="preserve"><value>Impossible de charger les couleurs. Veuillez réessayer.</value></data>
+  <data name="Colors.Error.UnexpectedError" xml:space="preserve"><value>Une erreur inattendue s'est produite. Veuillez réessayer.</value></data>
+</root>

--- a/src/Beagl.WebApp/Resources/Resources.ColorsResource.resx
+++ b/src/Beagl.WebApp/Resources/Resources.ColorsResource.resx
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, ...</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, ...</value></resheader>
+
+  <!-- Table headers -->
+  <data name="Colors.Table.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Colors.Table.NameEn" xml:space="preserve"><value>Name (EN)</value></data>
+  <data name="Colors.Table.NameFr" xml:space="preserve"><value>Name (FR)</value></data>
+  <data name="Colors.Table.Actions" xml:space="preserve"><value>Actions</value></data>
+
+  <!-- Actions -->
+  <data name="Colors.Action.Create" xml:space="preserve"><value>Add color</value></data>
+  <data name="Colors.Action.Edit" xml:space="preserve"><value>Edit color</value></data>
+  <data name="Colors.Action.Delete" xml:space="preserve"><value>Delete color</value></data>
+  <data name="Colors.Action.Save" xml:space="preserve"><value>Save</value></data>
+  <data name="Colors.Action.Cancel" xml:space="preserve"><value>Cancel</value></data>
+
+  <!-- Modal -->
+  <data name="Colors.Modal.Title.Create" xml:space="preserve"><value>Add color</value></data>
+  <data name="Colors.Modal.Title.Edit" xml:space="preserve"><value>Edit color</value></data>
+  <data name="Colors.Modal.Description.Create" xml:space="preserve"><value>Fill in the details to add a new color.</value></data>
+  <data name="Colors.Modal.Description.Edit" xml:space="preserve"><value>Update the color information below.</value></data>
+
+  <!-- Delete confirmation -->
+  <data name="Colors.Delete.Title" xml:space="preserve"><value>Delete color</value></data>
+  <data name="Colors.Delete.Confirmation" xml:space="preserve"><value>Are you sure you want to delete this color? This action cannot be undone.</value></data>
+  <data name="Colors.Delete.Confirm" xml:space="preserve"><value>Delete</value></data>
+
+  <!-- Form -->
+  <data name="Colors.Form.NameEn" xml:space="preserve"><value>Name (English)</value></data>
+  <data name="Colors.Form.NameFr" xml:space="preserve"><value>Name (French)</value></data>
+
+  <!-- Success messages -->
+  <data name="Colors.Success.Created" xml:space="preserve"><value>Color created successfully.</value></data>
+  <data name="Colors.Success.Updated" xml:space="preserve"><value>Color updated successfully.</value></data>
+  <data name="Colors.Success.Deleted" xml:space="preserve"><value>Color deleted successfully.</value></data>
+
+  <!-- Loading -->
+  <data name="Colors.Loading" xml:space="preserve"><value>Loading colors…</value></data>
+
+  <!-- Empty state -->
+  <data name="Colors.Empty.Title" xml:space="preserve"><value>No colors found</value></data>
+  <data name="Colors.Empty.Description" xml:space="preserve"><value>No colors have been added yet.</value></data>
+
+  <!-- Pagination -->
+  <data name="Colors.Pagination.Summary" xml:space="preserve"><value>Showing {0}–{1} of {2} colors</value></data>
+  <data name="Colors.Pagination.Aria" xml:space="preserve"><value>Color pagination</value></data>
+  <data name="Colors.Pagination.Previous" xml:space="preserve"><value>Previous</value></data>
+  <data name="Colors.Pagination.Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Colors.Pagination.Page" xml:space="preserve"><value>Page {0} of {1}</value></data>
+
+  <!-- Surface header -->
+  <data name="Colors.Directory.Title" xml:space="preserve"><value>Colors directory</value></data>
+  <data name="Colors.Directory.Description" xml:space="preserve"><value>Manage the animal colors available for selection in the system.</value></data>
+
+  <!-- Error codes from ColorService -->
+  <data name="color.name_en_required" xml:space="preserve"><value>English name is required.</value></data>
+  <data name="color.name_en_too_long" xml:space="preserve"><value>English name must not exceed 100 characters.</value></data>
+  <data name="color.name_fr_required" xml:space="preserve"><value>French name is required.</value></data>
+  <data name="color.name_fr_too_long" xml:space="preserve"><value>French name must not exceed 100 characters.</value></data>
+  <data name="color.duplicate_name" xml:space="preserve"><value>A color with this name already exists.</value></data>
+  <data name="color.not_found" xml:space="preserve"><value>The color was not found.</value></data>
+  <data name="color.in_use" xml:space="preserve"><value>Cannot delete a color that is currently in use.</value></data>
+
+  <!-- General errors -->
+  <data name="Colors.Error.LoadFailed" xml:space="preserve"><value>Failed to load colors. Please try again.</value></data>
+  <data name="Colors.Error.UnexpectedError" xml:space="preserve"><value>An unexpected error occurred. Please try again.</value></data>
+</root>

--- a/src/Beagl.WebApp/Resources/SharedResource.cs
+++ b/src/Beagl.WebApp/Resources/SharedResource.cs
@@ -66,6 +66,13 @@ internal sealed class BreedsResource
 }
 
 /// <summary>
+/// Marker type for color management localization resources.
+/// </summary>
+internal sealed class ColorsResource
+{
+}
+
+/// <summary>
 /// Marker type for citizen profile page localization resources.
 /// </summary>
 internal sealed class CitizenProfileResource

--- a/tests/Beagl.Application.Tests/Colors/Services/ColorServiceTests.cs
+++ b/tests/Beagl.Application.Tests/Colors/Services/ColorServiceTests.cs
@@ -1,0 +1,447 @@
+// MIT License - Copyright (c) 2025 Jonathan St-Michel
+
+using Beagl.Application.Colors.Dtos;
+using Beagl.Application.Colors.Services;
+using Beagl.Domain.Colors;
+using Beagl.Domain.Results;
+using FluentAssertions;
+using Moq;
+
+namespace Beagl.Application.Tests.Colors.Services;
+
+public class ColorServiceTests
+{
+    private readonly Mock<IColorRepository> _repositoryMock = new();
+
+    private ColorService CreateService() => new(_repositoryMock.Object);
+
+    public static IEnumerable<object[]> InvalidInputCases()
+    {
+        yield return new object[] { string.Empty, "Nom", "color.name_en_required" };
+        yield return new object[] { "   ", "Nom", "color.name_en_required" };
+        yield return new object[] { new string('a', 101), "Nom", "color.name_en_too_long" };
+        yield return new object[] { "Name", string.Empty, "color.name_fr_required" };
+        yield return new object[] { "Name", "   ", "color.name_fr_required" };
+        yield return new object[] { "Name", new string('a', 101), "color.name_fr_too_long" };
+    }
+
+    [Fact]
+    public void Constructor_WithNullRepository_ShouldThrowArgumentNullException()
+    {
+        // Act
+        Action act = () => _ = new ColorService(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetPageAsync_ShouldDelegateToRepository_AndReturnMappedDto()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color color = new(id, "Black", "Noir");
+        ColorsPage page = new([color], 1);
+
+        _repositoryMock
+            .Setup(r => r.GetPageAsync(It.IsAny<GetColorsPageQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(page);
+
+        ColorService service = CreateService();
+
+        // Act
+        ColorsPageDto result = await service.GetPageAsync(1, 10, CancellationToken.None);
+
+        // Assert
+        result.TotalCount.Should().Be(1);
+        result.Items.Should().ContainSingle();
+        result.Items[0].Id.Should().Be(id);
+        result.Items[0].NameEn.Should().Be("Black");
+        result.Items[0].NameFr.Should().Be("Noir");
+    }
+
+    [Fact]
+    public async Task GetPageAsync_ShouldPassQueryToRepository()
+    {
+        // Arrange
+        GetColorsPageQuery? capturedQuery = null;
+
+        _repositoryMock
+            .Setup(r => r.GetPageAsync(It.IsAny<GetColorsPageQuery>(), It.IsAny<CancellationToken>()))
+            .Callback<GetColorsPageQuery, CancellationToken>((q, _) => capturedQuery = q)
+            .ReturnsAsync(new ColorsPage([], 0));
+
+        ColorService service = CreateService();
+
+        // Act
+        await service.GetPageAsync(3, 25, CancellationToken.None);
+
+        // Assert
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Page.Should().Be(3);
+        capturedQuery.PageSize.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenColorExists_ShouldReturnMappedDto()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color color = new(id, "White", "Blanc");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(color);
+
+        ColorService service = CreateService();
+
+        // Act
+        ColorDto? result = await service.GetByIdAsync(id, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id);
+        result.NameEn.Should().Be("White");
+        result.NameFr.Should().Be("Blanc");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenColorNotFound_ShouldReturnNull()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Color?)null);
+
+        ColorService service = CreateService();
+
+        // Act
+        ColorDto? result = await service.GetByIdAsync(Guid.NewGuid(), CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithNullRequest_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        ColorService service = CreateService();
+
+        // Act
+        Func<Task> act = async () => await service.CreateAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithValidInput_ShouldReturnSuccess()
+    {
+        // Arrange
+        Color? capturedColor = null;
+
+        _repositoryMock
+            .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repositoryMock
+            .Setup(r => r.CreateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()))
+            .Callback<Color, CancellationToken>((c, _) => capturedColor = c)
+            .ReturnsAsync((Color c, CancellationToken _) => c);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("Brown", "Brun");
+
+        // Act
+        Result<ColorDto> result = await service.CreateAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.NameEn.Should().Be("Brown");
+        result.Value.NameFr.Should().Be("Brun");
+        capturedColor.Should().NotBeNull();
+        capturedColor!.Id.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldTrimInputValues()
+    {
+        // Arrange
+        Color? capturedColor = null;
+
+        _repositoryMock
+            .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repositoryMock
+            .Setup(r => r.CreateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()))
+            .Callback<Color, CancellationToken>((c, _) => capturedColor = c)
+            .ReturnsAsync((Color c, CancellationToken _) => c);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("  Brown  ", "  Brun  ");
+
+        // Act
+        await service.CreateAsync(request, CancellationToken.None);
+
+        // Assert
+        capturedColor!.NameEn.Should().Be("Brown");
+        capturedColor.NameFr.Should().Be("Brun");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithDuplicateName_ShouldReturnFailure()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("Black", "Noir");
+
+        // Act
+        Result<ColorDto> result = await service.CreateAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("color.duplicate_name");
+        _repositoryMock.Verify(r => r.CreateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidInputCases))]
+    public async Task CreateAsync_WithInvalidInput_ShouldReturnValidationFailure(
+        string nameEn,
+        string nameFr,
+        string expectedCode)
+    {
+        // Arrange
+        ColorService service = CreateService();
+        SaveColorRequest request = new(nameEn, nameFr);
+
+        // Act
+        Result<ColorDto> result = await service.CreateAsync(request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be(expectedCode);
+        _repositoryMock.Verify(r => r.CreateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithNullRequest_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        ColorService service = CreateService();
+
+        // Act
+        Func<Task> act = async () => await service.UpdateAsync(Guid.NewGuid(), null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenColorNotFound_ShouldReturnFailure()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Color?)null);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("Gray", "Gris");
+
+        // Act
+        Result<ColorDto> result = await service.UpdateAsync(Guid.NewGuid(), request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("color.not_found");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithValidInput_ShouldReturnSuccess()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color existing = new(id, "Black", "Noir");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        _repositoryMock
+            .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Color c, CancellationToken _) => c);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("Jet Black", "Noir jais");
+
+        // Act
+        Result<ColorDto> result = await service.UpdateAsync(id, request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.NameEn.Should().Be("Jet Black");
+        result.Value.NameFr.Should().Be("Noir jais");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldTrimInputValues()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color existing = new(id, "Black", "Noir");
+        Color? capturedColor = null;
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        _repositoryMock
+            .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()))
+            .Callback<Color, CancellationToken>((c, _) => capturedColor = c)
+            .ReturnsAsync((Color c, CancellationToken _) => c);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("  Jet Black  ", "  Noir jais  ");
+
+        // Act
+        await service.UpdateAsync(id, request, CancellationToken.None);
+
+        // Assert
+        capturedColor!.NameEn.Should().Be("Jet Black");
+        capturedColor.NameFr.Should().Be("Noir jais");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithDuplicateName_ShouldReturnFailure()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color existing = new(id, "Black", "Noir");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        _repositoryMock
+            .Setup(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        ColorService service = CreateService();
+        SaveColorRequest request = new("White", "Blanc");
+
+        // Act
+        Result<ColorDto> result = await service.UpdateAsync(id, request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("color.duplicate_name");
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidInputCases))]
+    public async Task UpdateAsync_WithInvalidInput_ShouldReturnValidationFailure(
+        string nameEn,
+        string nameFr,
+        string expectedCode)
+    {
+        // Arrange
+        ColorService service = CreateService();
+        SaveColorRequest request = new(nameEn, nameFr);
+
+        // Act
+        Result<ColorDto> result = await service.UpdateAsync(Guid.NewGuid(), request, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be(expectedCode);
+        _repositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Color>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenColorNotFound_ShouldReturnFailure()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Color?)null);
+
+        ColorService service = CreateService();
+
+        // Act
+        Result result = await service.DeleteAsync(Guid.NewGuid(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("color.not_found");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenColorInUse_ShouldReturnFailure()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color existing = new(id, "Orange", "Orange");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        _repositoryMock
+            .Setup(r => r.IsInUseAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        ColorService service = CreateService();
+
+        // Act
+        Result result = await service.DeleteAsync(id, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("color.in_use");
+        _repositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenColorExistsAndNotInUse_ShouldReturnSuccess()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+        Color existing = new(id, "Orange", "Orange");
+
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        _repositoryMock
+            .Setup(r => r.IsInUseAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repositoryMock
+            .Setup(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        ColorService service = CreateService();
+
+        // Act
+        Result result = await service.DeleteAsync(id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _repositoryMock.Verify(r => r.DeleteAsync(id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Add a color management section to the admin panel, enabling administrators to create, edit, and delete animal colors with bilingual names in French and English. Introduce a `Color` domain entity and implement full CRUD operations, mirroring the existing breed management structure. Include seed data with a comprehensive list of colors suitable for dogs and cats. Ensure localization for all UI elements and validation messages. Unit tests cover the application service layer for all CRUD operations.

Fixes #90