### PR TITLE
Add agent-authoring instructions and EF migration skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,8 @@ Use these scoped instruction files as the source of truth for detailed guidance:
     - Brand tokens, CRUD UI patterns, detail panel structure, accessibility expectations, and Blazor versus Razor Pages selection guidance for the WebApp
 - `.github/instructions/localization.instructions.md`
     - i18n rules, resource organization, bilingual requirements, localization key patterns
+- `.github/instructions/agent-authoring.instructions.md`
+    - Skill, agent, and prompt authoring rules — loaded only when editing `.github/**/*.md` files
 
 ---
 
@@ -61,20 +63,6 @@ Use these scoped instruction files as the source of truth for detailed guidance:
 - Code must be written in English, including identifiers, comments, and documentation.
 - Repository changes should respect existing project boundaries and folder structure.
 
----
 
-# Commit Messages
 
-- Use Conventional Commits in lowercase.
-- Use a single header line.
-- Keep the title under 72 characters.
-- Add bullet points in the body for grouped changes when useful.
-- Add `BREAKING CHANGE:` in the body if applicable.
 
----
-
-# Skill Authoring Guidance
-
-- Skills should reference only the smallest relevant instruction files instead of treating this file as a monolith.
-- Put reusable domain knowledge in scoped instruction files, not duplicated across many skills.
-- Keep skill files focused on workflow and trigger behavior; keep coding standards in `.github/instructions/`.

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: ".github/**/*.md"
+description: "Skill, agent, and prompt authoring guidance for Beagl. Applies when editing any customization file under .github/."
+---
+
+# Agent Authoring Instructions
+
+## Instruction Architecture
+
+- `copilot-instructions.md` is the always-on orientation document. Keep it short and stable — only project identity, domain map, and universal rules.
+- Put detailed coding rules in scoped files under `.github/instructions/` with targeted `applyTo` patterns.
+- Skills carry portable workflow knowledge that is reusable across projects. Keep coding standards in `.github/instructions/`, not duplicated in skills.
+- Agents and prompts reference skills for on-demand workflows. They do not duplicate the skill content inline.
+
+## Skill Reference Pattern
+
+When an agent or prompt relies on a workflow defined in a skill, reference it by name rather than repeating the steps:
+
+```
+Apply the `skill-name` skill.
+```
+
+When a project instruction file covers the same content, the project file takes precedence. Reference the skill as a fallback for portability:
+
+```
+Follow `.github/instructions/efcore.instructions.md` when present; otherwise apply the `ef-migration-workflow` skill.
+```
+
+## Agent Design Rules
+
+- Agent `description` must be self-contained and discovery-friendly. Use "Use when:" trigger phrases.
+- Do not write "Called by X only" — any agent should be directly invocable.
+- Each agent's "Instruction Source of Truth" section must use dynamic discovery (`all files under .github/instructions/`), not a hardcoded file list.
+- Always include a portable fallback in "Instruction Source of Truth" that references skills rather than prose.
+
+## Prompt Design Rules
+
+- Prompts should be a single focused trigger. Keep the body to one or two sentences.
+- Use `mode:` to target the right agent or subsystem directly.
+- Do not embed workflow logic in prompts — that belongs in the agent or skill.

--- a/.github/instructions/ui-design.instructions.md
+++ b/.github/instructions/ui-design.instructions.md
@@ -48,7 +48,6 @@ Use these rules for WebApp UI changes.
 - Do not use per-field `<ValidationMessage For="..." />` components. They render raw unlocalized strings.
 - Use a single consolidated validation summary block that iterates `_editContext.GetValidationMessages()` and renders each message through `L.LocalizeValidationMessage(message)`.
 - Place the validation summary inside `<EditForm>` after `<DataAnnotationsValidator />` and before the form fields.
-- See `localization.instructions.md` for the full validation pattern, key naming, and code example.
 
 ## Detail Panel Standard
 

--- a/.github/skills/ef-migration-workflow/SKILL.md
+++ b/.github/skills/ef-migration-workflow/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: ef-migration-workflow
+description: "Generate and configure an EF Core migration for Beagl. Use when adding or modifying DbSet properties, entity configurations, or Fluent API mappings in ApplicationDbContext. Covers command, migration naming, Up/Down review, and coverage exclusion."
+---
+
+# EF Core Migration Workflow — Beagl
+
+## When to Use
+
+Apply when the task adds or modifies `DbSet` properties, entity configurations, or Fluent API mappings. Skip when no schema changes are involved.
+
+See `.github/instructions/efcore.instructions.md` for the full EF Core data access rules.
+
+## Procedure
+
+1. Implement all entity classes, repository classes, and `DbContext` changes first.
+2. Run the migration command from the workspace root:
+   ```
+   dotnet ef migrations add <MigrationName> --project src/Beagl.Infrastructure --startup-project src/Beagl.WebApp
+   ```
+3. Use a descriptive PascalCase name (e.g. `AddBreeds`, `AddOwnerPayments`).
+4. Review the generated `Up`/`Down` methods for correctness.
+5. If the migration is empty or incorrect, delete it and diagnose the `DbContext` configuration.
+6. Exclude the migration from coverage — add to `src/Beagl.Infrastructure/Migrations/MigrationCoverageExclusions.g.cs`:
+   ```csharp
+   [ExcludeFromCodeCoverage] partial class <MigrationName> { }
+   ```


### PR DESCRIPTION
Introduce comprehensive guidance for skill, agent, and prompt authoring, along with a detailed EF Core migration workflow. Update the instruction map to streamline access to these resources. Remove redundant references to enhance clarity.